### PR TITLE
Fix: memory_word_limit was improperly being passed to openai provider wrappers

### DIFF
--- a/src/arcagi3/adapters/open_ai.py
+++ b/src/arcagi3/adapters/open_ai.py
@@ -222,14 +222,6 @@ IMPORTANT: Return ONLY the array, with no additional text, quotes, or formatting
             
             return None
         
-    def _filter_api_kwargs(self, kwargs):
-        """
-        Filter out internal configuration parameters that should not be passed to the API.
-        These are application-level settings, not API parameters.
-        """
-        internal_params = {'memory_word_limit'}
-        return {k: v for k, v in kwargs.items() if k not in internal_params}
-
     @retry_with_exponential_backoff(max_retries=3)
     def call_provider(self, messages):
         api_kwargs = self._filter_api_kwargs(self.model_config.kwargs)

--- a/src/arcagi3/adapters/open_ai.py
+++ b/src/arcagi3/adapters/open_ai.py
@@ -222,19 +222,28 @@ IMPORTANT: Return ONLY the array, with no additional text, quotes, or formatting
             
             return None
         
+    def _filter_api_kwargs(self, kwargs):
+        """
+        Filter out internal configuration parameters that should not be passed to the API.
+        These are application-level settings, not API parameters.
+        """
+        internal_params = {'memory_word_limit'}
+        return {k: v for k, v in kwargs.items() if k not in internal_params}
+
     @retry_with_exponential_backoff(max_retries=3)
     def call_provider(self, messages):
+        api_kwargs = self._filter_api_kwargs(self.model_config.kwargs)
         if self.model_config.api_type == "responses":
             messages = _convert_messages_to_responses_format(messages)
             return self.client.responses.create(
                 model=self.model_config.model_name,
                 input=messages,
-                **self.model_config.kwargs
+                **api_kwargs
             )
         else:
             return self.client.chat.completions.create(
                 model=self.model_config.model_name,
                 messages=messages,
-                **self.model_config.kwargs
+                **api_kwargs
             )
         

--- a/src/arcagi3/adapters/openai_base.py
+++ b/src/arcagi3/adapters/openai_base.py
@@ -46,6 +46,14 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         super().__init__(config)
         self._last_consumed_stream = None  # Cache for stream consumption
 
+    def _filter_api_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Filter out internal configuration parameters that should not be passed to the API.
+        These are application-level settings, not API parameters.
+        """
+        internal_params = {'memory_word_limit'}
+        return {k: v for k, v in kwargs.items() if k not in internal_params}
+
     @abc.abstractmethod
     def make_prediction(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:
         """
@@ -81,13 +89,14 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         Make a call to the OpenAI Chat Completions API
         """
-        logger.debug(f"Calling OpenAI API with model: {self.model_config.model_name} and kwargs: {self.model_config.kwargs}")
+        api_kwargs = self._filter_api_kwargs(self.model_config.kwargs)
+        logger.debug(f"Calling OpenAI API with model: {self.model_config.model_name} and kwargs: {api_kwargs}")
     
         
         return self.client.chat.completions.create(
             model=self.model_config.model_name,
             messages=messages,
-            **self.model_config.kwargs
+            **api_kwargs
         )
     
     def _chat_completion_stream(self, messages: List[Dict[str, str]]) -> ChatCompletion:
@@ -96,8 +105,8 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         logger.debug(f"Starting streaming chat completion for model: {self.model_config.model_name}")
         
-        # Prepare kwargs for streaming, removing 'stream' to avoid duplication
-        stream_kwargs = {k: v for k, v in self.model_config.kwargs.items() if k != 'stream'}
+        # Prepare kwargs for streaming, removing 'stream' to avoid duplication and filtering internal params
+        stream_kwargs = self._filter_api_kwargs({k: v for k, v in self.model_config.kwargs.items() if k != 'stream'})
         
         try:
             # Create the stream with usage tracking
@@ -188,11 +197,11 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         Make a call to the OpenAI Responses API
         """
-
+        api_kwargs = self._filter_api_kwargs(self.model_config.kwargs)
         resp = self.client.responses.create(
             model=self.model_config.model_name,
             input=messages,
-            **self.model_config.kwargs
+            **api_kwargs
         )
 
         # For background mode
@@ -217,8 +226,8 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         logger.debug(f"Starting streaming responses for model: {self.model_config.model_name}")
         
-        # Prepare kwargs for streaming, removing 'stream' to avoid duplication
-        stream_kwargs = {k: v for k, v in self.model_config.kwargs.items() if k != 'stream'}
+        # Prepare kwargs for streaming, removing 'stream' to avoid duplication and filtering internal params
+        stream_kwargs = self._filter_api_kwargs({k: v for k, v in self.model_config.kwargs.items() if k != 'stream'})
         
         try:
             # Create the stream
@@ -558,16 +567,17 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
     @retry_with_exponential_backoff(max_retries=3)
     def call_provider(self, messages):
         # For other providers, try OpenAI-compatible format
+        api_kwargs = self._filter_api_kwargs(self.model_config.kwargs)
         try:
             return self.client.chat.completions.create(
                 model=self.model_config.model_name,
                 messages=messages,
-                **self.model_config.kwargs
+                **api_kwargs
             )
         except AttributeError:
             # Fallback to direct client call
             return self.client.create(
                 model=self.model_config.model_name,
                 messages=messages,
-                **self.model_config.kwargs
+                **api_kwargs
             )

--- a/src/arcagi3/adapters/openai_base.py
+++ b/src/arcagi3/adapters/openai_base.py
@@ -50,9 +50,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         Filter out internal configuration parameters that should not be passed to the API.
         These are application-level settings, not API parameters.
+        Uses INTERNAL_API_PARAMS from ProviderAdapter base class.
         """
-        internal_params = {'memory_word_limit'}
-        return {k: v for k, v in kwargs.items() if k not in internal_params}
+        return {k: v for k, v in kwargs.items() if k not in ProviderAdapter.INTERNAL_API_PARAMS}
 
     @abc.abstractmethod
     def make_prediction(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:

--- a/src/arcagi3/adapters/provider.py
+++ b/src/arcagi3/adapters/provider.py
@@ -1,11 +1,17 @@
 import abc
-from typing import List, Dict, Tuple, Any, Optional
-import json
-from datetime import datetime
+from typing import List, Dict, Any, Optional, Set
 from arcagi3.schemas import Attempt, ModelConfig
 from arcagi3.utils.task_utils import read_models_config
 
 class ProviderAdapter(abc.ABC):
+    """
+    Base class for all provider adapters.
+    
+    INTERNAL_API_PARAMS: Set of parameter names that are application-level configuration
+    and should NOT be passed to provider APIs. These are filtered out before API calls.
+    """
+    INTERNAL_API_PARAMS: Set[str] = {'memory_word_limit'}
+    
     def __init__(self, config: str):
         """
         Initialize the provider adapter with model configuration.


### PR DESCRIPTION
As described; `memory_word_limit` param not being filtered and being passed to OpenAI provider calls, causing failure. Fix is to filter it out. Done so in a manner that allows us to expand the internal API commands later.

```
2025-12-08 12:31:19,605 - arcagi3.utils.retry - ERROR - Function call_provider failed after 3 retries. Last error: TypeError: Responses.create() got an unexpected keyword argument 'memory_word_limit'
2025-12-08 12:31:19,606 - arcagi3.agent - ERROR - Error during game loop: Responses.create() got an unexpected keyword argument 'memory_word_limit'
Traceback (most recent call last):
  File "/home/keith/projects/arc/arc-agi-3-benchmarking/src/arcagi3/agent.py", line 948, in _run_session_loop
    game_action_dict = self.step(frame_images, frame_grids, current_score)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/keith/projects/arc/arc-agi-3-benchmarking/src/arcagi3/agent.py", line 592, in step
    human_action_dict = self._choose_human_action(frame_images, frame_grids, analysis)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/keith/projects/arc/arc-agi-3-benchmarking/src/arcagi3/agent.py", line 553, in _choose_human_action
    response = self.provider.call_provider(messages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/keith/projects/arc/arc-agi-3-benchmarking/src/arcagi3/utils/retry.py", line 41, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/keith/projects/arc/arc-agi-3-benchmarking/src/arcagi3/adapters/open_ai.py", line 229, in call_provider
    return self.client.responses.create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Responses.create() got an unexpected keyword argument 'memory_word_limit'
```