### PR TITLE
Fix: harness diff images are blank

### DIFF
--- a/src/arcagi3/utils/context.py
+++ b/src/arcagi3/utils/context.py
@@ -520,9 +520,15 @@ class SessionContext:
         with self._lock:
             frames = self._frames
             game = self._game
+            # If the server returns the same frame payload again (common at the
+            # top of the next loop iteration), keep the prior "before action"
+            # snapshot instead of overwriting it with an identical "after action"
+            # frame. This preserves meaningful before/after comparisons for
+            # analyze-step diffs.
+            previous_grids = frames.previous_grids if new_grids == frames.frame_grids else frames.frame_grids
             self._frames = replace(
                 frames,
-                previous_grids=frames.frame_grids,
+                previous_grids=previous_grids,
                 frame_grids=new_grids,
             )
             self._game = replace(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -136,6 +136,40 @@ def test_context_update_preserves_previous_state():
     assert len(context.frames.previous_grids) == len(prev_grids)
 
 
+def test_context_update_same_frames_preserves_meaningful_previous_grids():
+    context = SessionContext()
+
+    # First server state for this loop (before action)
+    first_grids = [create_64x64_grid(1)]
+    context.update(
+        frame_grids=first_grids,
+        current_score=0,
+        current_state="IN_PROGRESS",
+    )
+    assert context.frames.previous_grids == ()
+    assert context.frames.frame_grids == tuple(first_grids)
+
+    # State after executing an action: this becomes current, and previous gets first_grids
+    second_grids = [create_64x64_grid(2)]
+    context.update(
+        frame_grids=second_grids,
+        current_score=0,
+        current_state="IN_PROGRESS",
+    )
+    assert context.frames.previous_grids == tuple(first_grids)
+    assert context.frames.frame_grids == tuple(second_grids)
+
+    # Next loop pre-step refresh often repeats the same second_grids payload.
+    # Ensure this does not clobber previous_grids.
+    context.update(
+        frame_grids=second_grids,
+        current_score=0,
+        current_state="IN_PROGRESS",
+    )
+    assert context.frames.previous_grids == tuple(first_grids)
+    assert context.frames.frame_grids == tuple(second_grids)
+
+
 def test_context_properties():
     context = SessionContext()
 


### PR DESCRIPTION
At some point the diff image is generated *after* writing the new state over the old one, causing the generated diff image to be a diff of the newest state versus itself; which is of course blank. This causes issue with models that decide to utilize the diff image/frame as key data to judge its progress.