### PR TITLE
Add OpenAI Responses API support with runtime adapter layer

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -408,6 +408,7 @@ class BenchmarkingAgent(Agent):
         data = action.action_data.model_dump()
         reasoning = getattr(action, "reasoning", {}) or {}
         raw = self.arc_env.step(action, data=data, reasoning=reasoning)
+        self._previous_action = action
         return self._convert_raw_frame_data(raw)
 
     # ── Core loop ────────────────────────────────────────────────────────

--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -15,15 +15,15 @@ from openai import OpenAI as OpenAIClient
 from .base import Agent
 from .exceptions import EmptyResponseError
 from .model_config import get_model_config
-from .models import (
-    ActionMetadata,
-    CostDetails,
-    InputTokensDetails,
-    OutputTokensDetails,
-    ResponseUsage,
-    calculate_cost,
-)
 from .recording import RunRecord, StepRecord, StepUsage
+from .runtime_adapters import build_model_runtime_adapter
+from .runtime_models import (
+    Message,
+    ModelRequest,
+    ModelResponse,
+    NormalizedUsage,
+    action_metadata_from_model_response,
+)
 
 logger = logging.getLogger()
 
@@ -42,6 +42,7 @@ class BenchmarkingAgent(Agent):
     MAX_RETRIES: int = 3
     MAX_CONTEXT_LENGTH: int = 100000
     MAX_ANIMATION_FRAMES: int = 7
+    analysis_mode: bool = False
     # Empirically, rendered ARC grid payloads are close to 1 char per token.
     # Using 1.0 is intentionally conservative relative to observed runs.
     ESTIMATED_CHARS_PER_TOKEN: float = 1.0
@@ -54,14 +55,16 @@ class BenchmarkingAgent(Agent):
         super().__init__(*args, **kwargs)
         if not self.config:
             raise ValueError(
-                "No model config specified. Pass --config=<config_name> when running main.py. "
+                "No model config specified. Pass --config=<config_id> when running main.py. "
                 "Use --list-configs to see available options."
             )
         self.MODEL_CONFIG_ID = self.config
         self.conversation: list[dict[str, Any]] = []
         self.token_counter: int = 0
 
-        agent_cfg, client_cfg, call_cfg, pricing_cfg = self._load_model_config()
+        agent_cfg, runtime_cfg, client_cfg, request_cfg, pricing_cfg = (
+            self._load_model_config()
+        )
         self._pricing: dict[str, float] = pricing_cfg
 
         # Agent-level overrides
@@ -75,6 +78,7 @@ class BenchmarkingAgent(Agent):
             "MAX_ANIMATION_FRAMES", self.MAX_ANIMATION_FRAMES
         )
         self.MAX_RETRIES = agent_cfg.get("MAX_RETRIES", self.MAX_RETRIES)
+        self.analysis_mode = agent_cfg.get("analysis_mode", self.analysis_mode)
 
         # Per-level action budgets from baseline_actions * multiplier.
         # MAX_ACTIONS becomes the derived total budget across all levels.
@@ -102,9 +106,9 @@ class BenchmarkingAgent(Agent):
         self._last_levels_completed: int = 0
         self._level_just_advanced: bool = False
 
-        # Call kwargs passed directly to chat.completions.create()
-        self.MODEL: str = call_cfg["model"]
-        self._call_kwargs: dict[str, Any] = call_cfg
+        # Adapter-specific request kwargs from the selected model config.
+        self.MODEL: str = request_cfg["model"]
+        self._request_kwargs: dict[str, Any] = request_cfg
 
         # Validate that the required API key is set before attempting any requests
         api_key_env = client_cfg["api_key_env"]
@@ -120,6 +124,11 @@ class BenchmarkingAgent(Agent):
         self._client = OpenAIClient(
             base_url=client_cfg["base_url"],
             api_key=api_key,
+        )
+        self._adapter = build_model_runtime_adapter(
+            client=self._client,
+            runtime_config=runtime_cfg,
+            config_id=self.MODEL_CONFIG_ID,
         )
         # Per-step recording
         self.step_counter: int = 0
@@ -138,15 +147,23 @@ class BenchmarkingAgent(Agent):
 
     def _load_model_config(
         self,
-    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, float]]:
+    ) -> tuple[
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, float],
+    ]:
         """Load config from model_configs.yaml matching MODEL_CONFIG_ID.
 
-        Returns four dicts: (agent_cfg, client_cfg, call_cfg, pricing_cfg).
+        Returns five dicts:
+        (agent_cfg, runtime_cfg, client_cfg, request_cfg, pricing_cfg).
         - agent_cfg:    agent-level settings
                         (MAX_ACTIONS_BASELINE_MULTIPLIER, MAX_CONTEXT_LENGTH, …)
+        - runtime_cfg:  execution profile (sdk, api)
         - client_cfg:   OpenAI client constructor args (base_url, api_key_env)
-        - call_cfg:     kwargs passed directly to chat.completions.create()
-                        (model, max_completion_tokens, reasoning_effort, …)
+        - request_cfg:  kwargs passed to the selected runtime adapter
+                        (model, max_completion_tokens, reasoning_effort, ...)
         - pricing_cfg:  per-million-token pricing (input, output)
 
         Raises ``ValueError`` if the YAML file is missing or no matching entry.
@@ -154,14 +171,15 @@ class BenchmarkingAgent(Agent):
         raw = get_model_config(self.MODEL_CONFIG_ID)
 
         agent_cfg: dict[str, Any] = dict(raw.get("agent", {}))
+        runtime_cfg: dict[str, Any] = dict(raw.get("runtime", {}))
         client_cfg: dict[str, Any] = dict(raw.get("client", {}))
-        call_cfg: dict[str, Any] = dict(raw.get("call", {}))
+        request_cfg: dict[str, Any] = dict(raw.get("request", {}))
         pricing_cfg: dict[str, float] = dict(raw.get("pricing", {}))
 
         client_cfg.setdefault("base_url", self._DEFAULT_BASE_URL)
         client_cfg.setdefault("api_key_env", self._DEFAULT_API_KEY_ENV)
 
-        return agent_cfg, client_cfg, call_cfg, pricing_cfg
+        return agent_cfg, runtime_cfg, client_cfg, request_cfg, pricing_cfg
 
     @property
     def name(self) -> str:
@@ -171,8 +189,29 @@ class BenchmarkingAgent(Agent):
     # ── Prompts ──────────────────────────────────────────────────────────
 
     def _build_system_prompt(self) -> str:
+        if self.analysis_mode:
+            return textwrap.dedent("""\
+                You are playing a game. Your goal is to win. Reply with the exact action you want to take. The final action in your reply will be executed next turn. Your entire reply will be carried to the next turn.
+
+                Prior assistant turns may include a <reasoning_summary> block before the prior action text. Treat those summaries as compact helper context about the earlier decision process, then continue by choosing the next action normally.
+            """)
         return textwrap.dedent("""\
             You are playing a game. Your goal is to win. Reply with the exact action you want to take. The final action in your reply will be executed next turn. Your entire reply will be carried to the next turn.
+        """)
+
+    def _build_assistant_turn_content(
+        self,
+        output_text: str,
+        reasoning_text: str | None,
+    ) -> str:
+        if not self.analysis_mode or not reasoning_text:
+            return output_text
+        return textwrap.dedent(f"""\
+            <reasoning_summary>
+            {reasoning_text}
+            </reasoning_summary>
+
+            {output_text}
         """)
 
     def _get_actions(self, latest_frame: FrameData) -> list[GameAction]:
@@ -329,6 +368,40 @@ class BenchmarkingAgent(Agent):
         self._write_run_meta()
         logger.info(f"Saved step {self.step_counter} to {filename}")
 
+    def _build_model_request(self) -> ModelRequest:
+        return ModelRequest(
+            messages=[Message.model_validate(message) for message in self.conversation],
+            request_config=dict(self._request_kwargs),
+        )
+
+    def _record_forced_action_observation(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+        forced_action: GameAction,
+    ) -> None:
+        self._sync_level_progress(latest_frame)
+        self._level_action_counter += 1
+
+        if forced_action == GameAction.RESET and latest_frame.state is GameState.GAME_OVER:
+            self.conversation.append(
+                {
+                    "role": "user",
+                    "content": self.build_frame_content(latest_frame),
+                }
+            )
+
+        self._save_step(
+            StepRecord(
+                step=self.step_counter + 1,
+                timestamp=datetime.now(timezone.utc),
+                duration_seconds=0.0,
+                model=self.MODEL,
+                messages_sent=list(self.conversation),
+                parsed_action=self._format_parsed_action(forced_action),
+            )
+        )
+
     # ── Action submission ──────────────────────────────────────────────
 
     def do_action_request(self, action: GameAction) -> FrameData:
@@ -370,30 +443,17 @@ class BenchmarkingAgent(Agent):
     def choose_action(
         self, frames: list[FrameData], latest_frame: FrameData
     ) -> GameAction:
+        forced_action = self._forced_action_for_frame(latest_frame)
+        if forced_action is not None:
+            self._record_forced_action_observation(
+                frames,
+                latest_frame,
+                forced_action,
+            )
+            return forced_action
+
         self._sync_level_progress(latest_frame)
         self._level_action_counter += 1
-
-        # Reset whenever the environment indicates the game is not currently playable.
-        # Show the game-over frame to the model so it sees why it died.
-        if latest_frame.state in (GameState.NOT_PLAYED, GameState.GAME_OVER):
-            if latest_frame.state == GameState.GAME_OVER:
-                self.conversation.append(
-                    {
-                        "role": "user",
-                        "content": self.build_frame_content(latest_frame),
-                    }
-                )
-            self._save_step(
-                StepRecord(
-                    step=self.step_counter + 1,
-                    timestamp=datetime.now(timezone.utc),
-                    duration_seconds=0.0,
-                    model=self.MODEL,
-                    messages_sent=list(self.conversation),
-                    parsed_action="RESET",
-                )
-            )
-            return GameAction.RESET
 
         # Ensure the system prompt is present before the first real turn
         if not self.conversation:
@@ -408,12 +468,21 @@ class BenchmarkingAgent(Agent):
 
         actions = self._get_actions(latest_frame)
         start = time.monotonic()
-        assistant_text, reasoning, action, step_usage, retries = (
-            self._request_with_retries(actions)
+        model_response, action, retries, messages_sent = self._request_with_retries(
+            actions
         )
         duration = round(time.monotonic() - start, 3)
+        step_usage = StepUsage.from_normalized_usage(model_response.usage)
 
-        self.conversation.append({"role": "assistant", "content": assistant_text})
+        self.conversation.append(
+            {
+                "role": "assistant",
+                "content": self._build_assistant_turn_content(
+                    model_response.output_text,
+                    model_response.reasoning_text,
+                ),
+            }
+        )
 
         logger.info(f"Parsed action: {self._format_parsed_action(action)}")
         self._save_step(
@@ -422,9 +491,9 @@ class BenchmarkingAgent(Agent):
                 timestamp=datetime.now(timezone.utc),
                 duration_seconds=duration,
                 model=self.MODEL,
-                messages_sent=list(self.conversation),
-                assistant_response=assistant_text,
-                reasoning=reasoning,
+                messages_sent=messages_sent,
+                assistant_response=model_response.output_text,
+                reasoning=model_response.reasoning_text,
                 parsed_action=self._format_parsed_action(action),
                 usage=step_usage,
                 retries=retries,
@@ -432,35 +501,16 @@ class BenchmarkingAgent(Agent):
         )
 
         # Build ActionMetadata and pass as dict through the reasoning field
-        usage_obj = ResponseUsage(
-            input_tokens=step_usage.prompt_tokens,
-            input_tokens_details=InputTokensDetails(
-                cached_tokens=step_usage.cached_tokens,
-            ),
-            output_tokens=step_usage.completion_tokens,
-            output_tokens_details=OutputTokensDetails(
-                reasoning_tokens=step_usage.reasoning_tokens,
-            ),
-            total_tokens=step_usage.total_tokens,
+        metadata = action_metadata_from_model_response(
+            model_response=model_response,
+            pricing=self._pricing,
         )
-        input_cost = calculate_cost(
-            step_usage.prompt_tokens, self._pricing.get("input", 0.0)
-        )
-        output_cost = calculate_cost(
-            step_usage.completion_tokens, self._pricing.get("output", 0.0)
-        )
-        total_cost = input_cost + output_cost
-        metadata = ActionMetadata(
-            output=assistant_text,
-            reasoning=reasoning,
-            usage=usage_obj,
-            cost=CostDetails(
-                input_cost=input_cost,
-                output_cost=output_cost,
-                total_cost=total_cost,
-            ),
-        )
+        if metadata.reasoning:
+            metadata.reasoning = metadata.reasoning[:12_000]
         action.reasoning = metadata.model_dump()
+        total_cost = metadata.cost.total_cost
+        input_cost = metadata.cost.input_cost
+        output_cost = metadata.cost.output_cost
         logger.info(
             f"Step cost: ${total_cost:.6f} "
             f"(input: ${input_cost:.6f}, output: ${output_cost:.6f})"
@@ -496,13 +546,22 @@ class BenchmarkingAgent(Agent):
 
     def _request_with_retries(
         self, actions: list[GameAction]
-    ) -> tuple[str, str | None, GameAction, StepUsage, int]:
-        """Call the API with retries. Returns (assistant_text, reasoning, action, usage, retries)."""
-        step_usage = StepUsage()
+    ) -> tuple[ModelResponse, GameAction, int, list[dict[str, Any]]]:
+        """Call the API with retries.
+
+        Returns (model_response, action, retries, messages_sent) where
+        messages_sent is the exact request transcript used by the successful
+        attempt before the current assistant reply is appended locally.
+        """
+        accumulated_usage = NormalizedUsage()
         for attempt in range(self.MAX_RETRIES + 1):
             try:
-                response = self._call_api()
-            except EmptyResponseError:
+                self._trim_to_fit_context()
+                model_request = self._build_model_request()
+                model_response = self._call_api(model_request)
+            except EmptyResponseError as e:
+                if e.response is not None:
+                    self._save_diagnostic(e.response)
                 logger.warning(
                     f"Empty API response "
                     f"(attempt {attempt + 1}/{self.MAX_RETRIES + 1})."
@@ -515,17 +574,21 @@ class BenchmarkingAgent(Agent):
                 )
                 continue
 
-            step_usage = step_usage + StepUsage.from_response(response)
-            msg = response.choices[0].message
-            assistant_text = msg.content or ""
-            reasoning = getattr(msg, "reasoning", None) or getattr(
-                msg, "reasoning_content", None
+            self.track_tokens(model_response.usage.total_tokens)
+            accumulated_usage = accumulated_usage + model_response.usage
+            model_response = model_response.model_copy(
+                update={"usage": accumulated_usage}
             )
-            logger.info(f"Assistant response: {assistant_text[:200]}")
+            logger.info(f"Assistant response: {model_response.output_text[:200]}")
 
-            action = self._parse_action(assistant_text, actions)
+            action = self._parse_action(model_response.output_text, actions)
             if action is not None:
-                return assistant_text, reasoning, action, step_usage, attempt
+                return (
+                    model_response,
+                    action,
+                    attempt,
+                    [message.model_dump() for message in model_request.messages],
+                )
 
             logger.warning(
                 f"Could not parse action from response "
@@ -536,24 +599,8 @@ class BenchmarkingAgent(Agent):
             f"Failed to get a valid action after {self.MAX_RETRIES + 1} attempts."
         )
 
-    def _call_api(self) -> Any:
-        self._trim_to_fit_context()
-
-        response = self._client.chat.completions.create(
-            messages=self.conversation,
-            **self._call_kwargs,
-        )
-
-        if not response.choices:
-            self._save_diagnostic(response)
-            raise EmptyResponseError(
-                f"API returned 200 with empty choices. "
-                f"Diagnostics saved to {self.run_dir}"
-            )
-
-        if response.usage:
-            self.track_tokens(response.usage.total_tokens)
-        return response
+    def _call_api(self, model_request: ModelRequest) -> ModelResponse:
+        return self._adapter.invoke(model_request)
 
     def _trim_oldest_turn(self) -> bool:
         """Remove the oldest user/assistant pair, preserving the system message."""

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -69,12 +69,10 @@ class Agent(ABC):
             not self.is_done(self.frames, self.frames[-1])
             and self.action_counter <= self.MAX_ACTIONS
         ):
-            action = self.choose_action(
-                self.frames,
-                self._convert_raw_frame_data(
-                    self.arc_env.observation_space if self.arc_env else None
-                ),
+            latest_frame = self._convert_raw_frame_data(
+                self.arc_env.observation_space if self.arc_env else None
             )
+            action = self._resolve_action(self.frames, latest_frame)
             if frame := self.take_action(action):
                 self.append_frame(frame)
                 logger.info(
@@ -124,18 +122,39 @@ class Agent(ABC):
     def is_reset_a_valid_action(self) -> bool:
         return self.action_counter > 0 and self._previous_action != GameAction.RESET
 
+    def _resolve_action(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+    ) -> GameAction:
+        forced_action = self._forced_action_for_frame(latest_frame)
+        if forced_action is not None:
+            self._record_forced_action_observation(frames, latest_frame, forced_action)
+            return forced_action
+        return self.choose_action(frames, latest_frame)
+
+    @staticmethod
+    def _forced_action_for_frame(latest_frame: FrameData) -> Optional[GameAction]:
+        if latest_frame.state in (GameState.GAME_OVER, GameState.NOT_PLAYED):
+            return GameAction.RESET
+        return None
+
+    def _record_forced_action_observation(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+        forced_action: GameAction,
+    ) -> None:
+        return None
+
     def do_action_request(self, action: GameAction) -> FrameData:
         data = action.action_data.model_dump()
 
-        if self.is_reset_a_valid_action():
-            raw = self.arc_env.step(
-                action,
-                data=data,
-                reasoning=data["reasoning"] if "reasoning" in data else {},
-            )
-        else:
-            return self.frames[-1]
-
+        raw = self.arc_env.step(
+            action,
+            data=data,
+            reasoning=data["reasoning"] if "reasoning" in data else {},
+        )
         self._previous_action = action
 
         return self._convert_raw_frame_data(raw)

--- a/benchmarking/cli_list.py
+++ b/benchmarking/cli_list.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .model_config import list_model_config_ids
+
+
+def _print_values(title: str, values: list[str]) -> None:
+    print(f"{title}:")
+    for value in sorted(values):
+        if title == "Games":
+            print("-", value.split("-")[0])
+        else:
+            print("-", value)
+
+
+def print_requested_resource_lists(
+    args: argparse.Namespace,
+    *,
+    root_url: str,
+    fetch_available_games: Callable[[str], list[str]],
+) -> bool:
+    """Print requested list commands and report whether main() should exit early."""
+    requested_lists: list[tuple[str, list[str]]] = []
+
+    if args.list_configs:
+        requested_lists.append(("Configs", list_model_config_ids()))
+    if args.list_games:
+        requested_lists.append(("Games", fetch_available_games(root_url)))
+
+    if not requested_lists:
+        return False
+
+    for index, (title, values) in enumerate(requested_lists):
+        if index > 0:
+            print()
+        _print_values(title, values)
+
+    return True

--- a/benchmarking/exceptions.py
+++ b/benchmarking/exceptions.py
@@ -1,2 +1,6 @@
 class EmptyResponseError(Exception):
     """Raised when the API returns HTTP 200 but with null/empty choices."""
+
+    def __init__(self, message: str, response: object | None = None) -> None:
+        super().__init__(message)
+        self.response = response

--- a/benchmarking/model_config.py
+++ b/benchmarking/model_config.py
@@ -4,16 +4,21 @@ from typing import Any
 import yaml
 
 MODEL_CONFIG_PATH = Path(__file__).resolve().parent / "model_configs.yaml"
+REQUIRED_CONFIG_SECTIONS = ("runtime", "client", "request")
+SUPPORTED_RUNTIME_APIS = frozenset({"chat_completions", "responses"})
+SUPPORTED_RUNTIME_STATE = "manual_rolling"
 
 
-def load_model_configs() -> list[dict[str, Any]]:
+def _read_raw_model_configs() -> list[dict[str, Any]]:
     if not MODEL_CONFIG_PATH.exists():
         raise ValueError(f"Model config file not found: {MODEL_CONFIG_PATH}")
 
     try:
         configs = yaml.safe_load(MODEL_CONFIG_PATH.read_text()) or []
     except OSError as e:
-        raise ValueError(f"Failed to read model config file {MODEL_CONFIG_PATH}: {e}") from e
+        raise ValueError(
+            f"Failed to read model config file {MODEL_CONFIG_PATH}: {e}"
+        ) from e
 
     if not isinstance(configs, list):
         raise ValueError(f"Model config file is invalid: {MODEL_CONFIG_PATH}")
@@ -21,19 +26,83 @@ def load_model_configs() -> list[dict[str, Any]]:
     return configs
 
 
-def list_model_config_ids() -> list[str]:
+def _validate_model_config_entry(entry: Any, index: int, seen_ids: set[str]) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"Model config entry #{index} in {MODEL_CONFIG_PATH} must be a mapping."
+        )
+
+    raw_config_id = entry.get("id")
+    if not isinstance(raw_config_id, str) or not raw_config_id.strip():
+        legacy_name = entry.get("name")
+        if isinstance(legacy_name, str) and legacy_name.strip():
+            raise ValueError(
+                f"Model config entry #{index} uses legacy field 'name'. "
+                f"Rename it to 'id'."
+            )
+        raise ValueError(
+            f"Model config entry #{index} is missing required 'id'."
+        )
+
+    config_id = raw_config_id.strip()
+    if config_id in seen_ids:
+        raise ValueError(
+            f"Duplicate model config id '{config_id}' found in {MODEL_CONFIG_PATH}."
+        )
+    seen_ids.add(config_id)
+
+    for section in REQUIRED_CONFIG_SECTIONS:
+        if not isinstance(entry.get(section), dict):
+            raise ValueError(
+                f"Model config '{config_id}' is missing required section '{section}'."
+            )
+
+    agent = entry.get("agent", {})
+    if agent is not None and not isinstance(agent, dict):
+        raise ValueError(
+            f"Model config '{config_id}' section 'agent' must be a mapping if present."
+        )
+    if isinstance(agent, dict) and "analysis_mode" in agent:
+        if not isinstance(agent["analysis_mode"], bool):
+            raise ValueError(
+                f"Model config '{config_id}' agent.analysis_mode must be a boolean."
+            )
+
+    runtime = entry["runtime"]
+    if not isinstance(runtime.get("sdk"), str) or not runtime["sdk"].strip():
+        raise ValueError(f"Model config '{config_id}' is missing runtime.sdk.")
+    if not isinstance(runtime.get("api"), str) or not runtime["api"].strip():
+        raise ValueError(f"Model config '{config_id}' is missing runtime.api.")
+    if runtime["api"] not in SUPPORTED_RUNTIME_APIS:
+        supported_apis = ", ".join(sorted(SUPPORTED_RUNTIME_APIS))
+        raise ValueError(
+            f"Model config '{config_id}' uses runtime.api={runtime['api']!r}, "
+            f"but only {supported_apis} are supported."
+        )
+    if runtime.get("state") != SUPPORTED_RUNTIME_STATE:
+        raise ValueError(
+            f"Model config '{config_id}' uses runtime.state={runtime.get('state')!r}, "
+            f"but only '{SUPPORTED_RUNTIME_STATE}' is supported."
+        )
+
+    return entry
+
+
+def load_model_configs() -> list[dict[str, Any]]:
+    seen_ids: set[str] = set()
     return [
-        name
-        for entry in load_model_configs()
-        if isinstance(entry, dict)
-        for name in [entry.get("name")]
-        if isinstance(name, str) and name.strip()
+        _validate_model_config_entry(entry, index, seen_ids)
+        for index, entry in enumerate(_read_raw_model_configs(), start=1)
     ]
+
+
+def list_model_config_ids() -> list[str]:
+    return [entry["id"] for entry in load_model_configs()]
 
 
 def get_model_config(config_id: str) -> dict[str, Any]:
     for entry in load_model_configs():
-        if entry.get("name") == config_id:
+        if entry["id"] == config_id:
             return entry
 
     available_configs = ", ".join(sorted(list_model_config_ids()))

--- a/benchmarking/model_configs.yaml
+++ b/benchmarking/model_configs.yaml
@@ -89,6 +89,28 @@
     input: 2.50
     output: 15.00
 
+- id: "openai-gpt-5-4-2026-03-05-responses-analysis"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+    analysis_mode: true
+  runtime:
+    sdk: "openai-python"
+    api: "responses"
+    state: "manual_rolling"
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_output_tokens: 128_000
+    reasoning:
+      effort: "low"
+      summary: "auto"
+  pricing:
+    input: 2.50
+    output: 15.00
+
 - id: "openai-gpt-5-4-2026-03-05-xhigh"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0

--- a/benchmarking/model_configs.yaml
+++ b/benchmarking/model_configs.yaml
@@ -1,36 +1,49 @@
-- name: "openai-gpt-5.4-openrouter"
+- id: "openai-gpt-5.4-openrouter"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://openrouter.ai/api/v1"
     api_key_env: "OPENROUTER_API_KEY"
-  call:
+  request:
     model: "openai/gpt-5.4"
     max_completion_tokens: 1_000_000
+  pricing: {}
 
-- name: "anthropic-opus-4-6"
+- id: "anthropic-opus-4-6"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://api.anthropic.com/v1/"
     api_key_env: "ANTHROPIC_API_KEY"
-  call:
+  request:
     model: "claude-opus-4-6"
     max_tokens: 128_000
   pricing:
     input: 5.00
     output: 25.00
 
-- name: "anthropic-opus-4-6-max-effort"
+- id: "anthropic-opus-4-6-max-effort"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://api.anthropic.com/v1/"
     api_key_env: "ANTHROPIC_API_KEY"
-  call:
+  request:
     model: "claude-opus-4-6"
     max_tokens: 128_000
     extra_body:
@@ -40,28 +53,54 @@
     input: 5.00
     output: 25.00
 
-- name: "openai-gpt-5-4-2026-03-05"
+- id: "openai-gpt-5-4-2026-03-05"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://api.openai.com/v1"
     api_key_env: "OPENAI_API_KEY"
-  call:
+  request:
     model: "gpt-5.4-2026-03-05"
     max_completion_tokens: 128_000
   pricing:
     input: 2.50
     output: 15.00
 
-- name: "openai-gpt-5-4-2026-03-05-xhigh"
+- id: "openai-gpt-5-4-2026-03-05-responses"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "responses"
+    state: "manual_rolling"
   client:
     base_url: "https://api.openai.com/v1"
     api_key_env: "OPENAI_API_KEY"
-  call:
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_output_tokens: 128_000
+  pricing:
+    input: 2.50
+    output: 15.00
+
+- id: "openai-gpt-5-4-2026-03-05-xhigh"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+  request:
     model: "gpt-5.4-2026-03-05"
     max_completion_tokens: 128_000
     reasoning_effort: "xhigh"
@@ -69,14 +108,18 @@
     input: 2.50
     output: 15.00
 
-- name: "openai-gpt-5-4-2026-03-05-high"
+- id: "openai-gpt-5-4-2026-03-05-high"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://api.openai.com/v1"
     api_key_env: "OPENAI_API_KEY"
-  call:
+  request:
     model: "gpt-5.4-2026-03-05"
     max_completion_tokens: 128_000
     reasoning_effort: "high"
@@ -84,28 +127,55 @@
     input: 2.50
     output: 15.00
 
-- name: "xai-grok-4-20-beta-0309-reasoning"
+- id: "openai-gpt-5-4-2026-03-05-low"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_completion_tokens: 128_000
+    reasoning_effort: "high"
+  pricing:
+    input: 2.50
+    output: 15.00
+
+- id: "xai-grok-4-20-beta-0309-reasoning"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://api.x.ai/v1"
     api_key_env: "XAI_API_KEY"
-  call:
+  request:
     model: "grok-4.20-beta-0309-reasoning"
     max_tokens: 128_000
   pricing:
     input: 2.00
     output: 6.00
 
-- name: "google-gemini-3-1-pro-preview"
+- id: "google-gemini-3-1-pro-preview"
   agent:
     MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
     MAX_CONTEXT_LENGTH: 175_000
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
   client:
     base_url: "https://generativelanguage.googleapis.com/v1beta/openai/"
     api_key_env: "GOOGLE_API_KEY"
-  call:
+  request:
     model: "gemini-3.1-pro-preview"
     max_tokens: 128_000
   pricing:

--- a/benchmarking/recording.py
+++ b/benchmarking/recording.py
@@ -7,6 +7,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
+from .runtime_models import NormalizedUsage
+
 
 class StepUsage(BaseModel):
     """Token usage and cost for a single step (or accumulated across a run)."""
@@ -65,6 +67,19 @@ class StepUsage(BaseModel):
         if "cost_details" in extras:
             kwargs["cost_details"] = extras["cost_details"]
         return cls(**kwargs)
+
+    @classmethod
+    def from_normalized_usage(cls, usage: NormalizedUsage) -> StepUsage:
+        return cls(
+            prompt_tokens=usage.input_tokens,
+            completion_tokens=usage.output_tokens,
+            total_tokens=usage.total_tokens,
+            reasoning_tokens=usage.reasoning_tokens,
+            cached_tokens=usage.cached_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+            cost=usage.cost,
+            cost_details=dict(usage.cost_details),
+        )
 
 
 class StepRecord(BaseModel):

--- a/benchmarking/runtime_adapters.py
+++ b/benchmarking/runtime_adapters.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .runtime_models import (
+    ModelRequest,
+    ModelResponse,
+    normalize_chat_completion_response,
+    normalize_responses_response,
+)
+
+SUPPORTED_RUNTIME_STATE = "manual_rolling"
+
+
+class ModelRuntimeAdapter(Protocol):
+    def invoke(self, request: ModelRequest) -> ModelResponse: ...
+
+
+class OpenAIChatCompletionsAdapter:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def invoke(self, request: ModelRequest) -> ModelResponse:
+        raw_response = self._client.chat.completions.create(
+            messages=[message.model_dump() for message in request.messages],
+            **request.request_config,
+        )
+        return normalize_chat_completion_response(raw_response)
+
+
+class OpenAIResponsesAdapter:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @staticmethod
+    def _build_request_kwargs(request: ModelRequest) -> dict[str, Any]:
+        request_kwargs = dict(request.request_config)
+        request_kwargs.pop("previous_response_id", None)
+        request_kwargs.pop("conversation", None)
+
+        messages = [message.model_dump() for message in request.messages]
+        if request.messages and request.messages[0].role == "system":
+            request_kwargs["instructions"] = request.messages[0].content
+            request_kwargs["input"] = messages[1:]
+            return request_kwargs
+
+        request_kwargs["input"] = messages
+        return request_kwargs
+
+    def invoke(self, request: ModelRequest) -> ModelResponse:
+        raw_response = self._client.responses.create(
+            **self._build_request_kwargs(request),
+        )
+        return normalize_responses_response(raw_response)
+
+
+def build_model_runtime_adapter(
+    *,
+    client: Any,
+    runtime_config: dict[str, Any],
+    config_id: str,
+) -> ModelRuntimeAdapter:
+    runtime_state = runtime_config.get("state")
+    if runtime_state != SUPPORTED_RUNTIME_STATE:
+        raise ValueError(
+            f"Model config '{config_id}' uses runtime.state={runtime_state!r}, "
+            f"but only '{SUPPORTED_RUNTIME_STATE}' is supported in phase 3."
+        )
+
+    runtime_key = (runtime_config.get("sdk"), runtime_config.get("api"))
+    if runtime_key == ("openai-python", "chat_completions"):
+        return OpenAIChatCompletionsAdapter(client)
+    if runtime_key == ("openai-python", "responses"):
+        return OpenAIResponsesAdapter(client)
+
+    raise ValueError(
+        f"Model config '{config_id}' uses unsupported runtime "
+        f"(sdk={runtime_config.get('sdk')!r}, api={runtime_config.get('api')!r})."
+    )

--- a/benchmarking/runtime_models.py
+++ b/benchmarking/runtime_models.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .exceptions import EmptyResponseError
+from .models import (
+    ActionMetadata,
+    CostDetails,
+    InputTokensDetails,
+    OutputTokensDetails,
+    ResponseUsage,
+    calculate_cost,
+)
+
+
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class ModelRequest(BaseModel):
+    messages: list[Message]
+    request_config: dict[str, Any]
+
+
+class NormalizedUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    reasoning_tokens: int = 0
+    cached_tokens: int = 0
+    cache_write_tokens: int = 0
+    cost: float = 0.0
+    cost_details: dict[str, float] = Field(default_factory=dict)
+
+    def __add__(self, other: NormalizedUsage) -> NormalizedUsage:
+        merged_cost_details: dict[str, float] = {}
+        for key in set(
+            list(self.cost_details.keys()) + list(other.cost_details.keys())
+        ):
+            merged_cost_details[key] = self.cost_details.get(
+                key, 0.0
+            ) + other.cost_details.get(key, 0.0)
+        return NormalizedUsage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+            reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
+            cached_tokens=self.cached_tokens + other.cached_tokens,
+            cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+            cost=self.cost + other.cost,
+            cost_details=merged_cost_details,
+        )
+
+
+class ModelResponse(BaseModel):
+    output_text: str
+    reasoning_text: str | None = None
+    usage: NormalizedUsage
+    raw_response: Any | None = None
+
+
+def _value_from_response_object(item: Any, key: str, default: Any = None) -> Any:
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+def _normalize_chat_usage(usage: Any) -> dict[str, Any]:
+    if not usage:
+        return {}
+
+    normalized_usage_kwargs: dict[str, Any] = {
+        "input_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+        "output_tokens": getattr(usage, "completion_tokens", 0) or 0,
+        "total_tokens": getattr(usage, "total_tokens", 0) or 0,
+    }
+    if getattr(usage, "completion_tokens_details", None):
+        normalized_usage_kwargs["reasoning_tokens"] = (
+            usage.completion_tokens_details.reasoning_tokens or 0
+        )
+    if getattr(usage, "prompt_tokens_details", None):
+        normalized_usage_kwargs["cached_tokens"] = (
+            usage.prompt_tokens_details.cached_tokens or 0
+        )
+        normalized_usage_kwargs["cache_write_tokens"] = (
+            getattr(usage.prompt_tokens_details, "cache_write_tokens", 0) or 0
+        )
+    extras = getattr(usage, "model_extra", {}) or {}
+    if "cost" in extras:
+        normalized_usage_kwargs["cost"] = extras["cost"]
+    if "cost_details" in extras:
+        normalized_usage_kwargs["cost_details"] = extras["cost_details"]
+    return normalized_usage_kwargs
+
+
+def _normalize_responses_usage(usage: Any) -> dict[str, Any]:
+    if not usage:
+        return {}
+
+    normalized_usage_kwargs: dict[str, Any] = {
+        "input_tokens": _value_from_response_object(usage, "input_tokens", 0) or 0,
+        "output_tokens": _value_from_response_object(usage, "output_tokens", 0) or 0,
+        "total_tokens": _value_from_response_object(usage, "total_tokens", 0) or 0,
+    }
+    output_tokens_details = _value_from_response_object(
+        usage,
+        "output_tokens_details",
+    )
+    if output_tokens_details:
+        normalized_usage_kwargs["reasoning_tokens"] = (
+            _value_from_response_object(output_tokens_details, "reasoning_tokens", 0)
+            or 0
+        )
+    input_tokens_details = _value_from_response_object(
+        usage,
+        "input_tokens_details",
+    )
+    if input_tokens_details:
+        normalized_usage_kwargs["cached_tokens"] = (
+            _value_from_response_object(input_tokens_details, "cached_tokens", 0)
+            or 0
+        )
+        normalized_usage_kwargs["cache_write_tokens"] = (
+            _value_from_response_object(
+                input_tokens_details,
+                "cache_write_tokens",
+                0,
+            )
+            or 0
+        )
+    extras = _value_from_response_object(usage, "model_extra", {}) or {}
+    if "cost" in extras:
+        normalized_usage_kwargs["cost"] = extras["cost"]
+    if "cost_details" in extras:
+        normalized_usage_kwargs["cost_details"] = extras["cost_details"]
+    return normalized_usage_kwargs
+
+
+def _extract_responses_output_text(response: Any) -> str:
+    helper_text = _value_from_response_object(response, "output_text")
+    if helper_text is not None:
+        return helper_text
+
+    output_items = _value_from_response_object(response, "output", []) or []
+    if not output_items:
+        raise EmptyResponseError(
+            "API returned 200 with empty output.",
+            response=response,
+        )
+
+    text_parts: list[str] = []
+    found_message_item = False
+    for item in output_items:
+        if _value_from_response_object(item, "type") != "message":
+            continue
+        role = _value_from_response_object(item, "role")
+        if role not in (None, "assistant"):
+            continue
+        found_message_item = True
+        for content_item in _value_from_response_object(item, "content", []) or []:
+            if _value_from_response_object(content_item, "type") != "output_text":
+                continue
+            text_parts.append(_value_from_response_object(content_item, "text", "") or "")
+
+    if not found_message_item:
+        raise EmptyResponseError(
+            "API returned 200 with empty output.",
+            response=response,
+        )
+
+    return "".join(text_parts)
+
+
+def _extract_reasoning_text_fragment(item: Any) -> str | None:
+    if isinstance(item, str):
+        return item
+    return (
+        _value_from_response_object(item, "text")
+        or _value_from_response_object(item, "summary_text")
+    )
+
+
+def _extract_responses_reasoning_text(response: Any) -> str | None:
+    output_items = _value_from_response_object(response, "output", []) or []
+    reasoning_parts: list[str] = []
+
+    for item in output_items:
+        if _value_from_response_object(item, "type") != "reasoning":
+            continue
+
+        for summary_item in _value_from_response_object(item, "summary", []) or []:
+            fragment = _extract_reasoning_text_fragment(summary_item)
+            if fragment:
+                reasoning_parts.append(fragment)
+
+        for content_item in _value_from_response_object(item, "content", []) or []:
+            fragment = _extract_reasoning_text_fragment(content_item)
+            if fragment:
+                reasoning_parts.append(fragment)
+
+    if not reasoning_parts:
+        return None
+    return "\n".join(reasoning_parts)
+
+
+def normalize_chat_completion_response(response: Any) -> ModelResponse:
+    if not getattr(response, "choices", None):
+        raise EmptyResponseError(
+            "API returned 200 with empty choices.",
+            response=response,
+        )
+
+    message = response.choices[0].message
+    usage = getattr(response, "usage", None)
+
+    return ModelResponse(
+        output_text=message.content or "",
+        reasoning_text=getattr(message, "reasoning", None)
+        or getattr(message, "reasoning_content", None),
+        usage=NormalizedUsage(**_normalize_chat_usage(usage)),
+        raw_response=response,
+    )
+
+
+def normalize_responses_response(response: Any) -> ModelResponse:
+    return ModelResponse(
+        output_text=_extract_responses_output_text(response),
+        reasoning_text=_extract_responses_reasoning_text(response),
+        usage=NormalizedUsage(
+            **_normalize_responses_usage(
+                _value_from_response_object(response, "usage"),
+            )
+        ),
+        raw_response=response,
+    )
+
+
+def action_metadata_from_model_response(
+    model_response: ModelResponse,
+    pricing: dict[str, float],
+) -> ActionMetadata:
+    input_cost = calculate_cost(model_response.usage.input_tokens, pricing.get("input", 0.0))
+    output_cost = calculate_cost(
+        model_response.usage.output_tokens, pricing.get("output", 0.0)
+    )
+    return ActionMetadata(
+        output=model_response.output_text,
+        reasoning=model_response.reasoning_text,
+        usage=ResponseUsage(
+            input_tokens=model_response.usage.input_tokens,
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=model_response.usage.cached_tokens,
+            ),
+            output_tokens=model_response.usage.output_tokens,
+            output_tokens_details=OutputTokensDetails(
+                reasoning_tokens=model_response.usage.reasoning_tokens,
+            ),
+            total_tokens=model_response.usage.total_tokens,
+        ),
+        cost=CostDetails(
+            input_cost=input_cost,
+            output_cost=output_cost,
+            total_cost=input_cost + output_cost,
+        ),
+    )

--- a/docs/analysis_mode.md
+++ b/docs/analysis_mode.md
@@ -1,0 +1,387 @@
+# Analysis Mode Plan
+
+## Goal
+
+Add an opt-in **analysis replay mode** for the benchmarking agent where each prior assistant turn can be replayed to the model with its saved reasoning summary inserted inline before the assistant's final action text.
+
+This mode should let a future model call see:
+
+- what the previous assistant said
+- the previous assistant's reasoning summary
+- the final action text in a clear "reasoning first, action second" layout
+
+Normal runs should remain unchanged unless this mode is explicitly enabled in the model config.
+
+When analysis mode is enabled, the agent should also route to a slightly more helper-oriented
+system prompt so the model is explicitly instructed to use the replayed reasoning summaries as
+supporting context. When analysis mode is disabled, it should keep the current baseline system
+prompt unchanged.
+
+## Current State
+
+The current code is already close to the right shape, but reasoning summaries are recorded and then discarded from future prompt context:
+
+- `BenchmarkingAgent.conversation` is a rolling transcript of plain `{"role", "content"}` messages.
+- `BenchmarkingAgent._build_model_request()` converts that transcript directly into `ModelRequest(messages=[Message(...), ...])` using the current system prompt.
+- `BenchmarkingAgent.choose_action()` appends only `model_response.output_text` to `self.conversation` for the assistant turn.
+- `StepRecord.reasoning` records `model_response.reasoning_text`, but that reasoning text is not replayed into later turns.
+- `OpenAIResponsesAdapter` consumes `ModelRequest.messages` and maps the first `system` message to `instructions`, then sends the rest as `input`.
+- `normalize_responses_response()` already extracts human-readable reasoning summaries into `ModelResponse.reasoning_text`.
+
+Relevant files:
+
+- `benchmarking/agent.py`
+- `benchmarking/runtime_models.py`
+- `benchmarking/runtime_adapters.py`
+- `benchmarking/recording.py`
+- `benchmarking/model_configs.yaml`
+
+## Recommendation
+
+Implement analysis replay as an **agent-level transcript rendering mode**.
+
+Do not change the runtime adapter contract for the first implementation. The runtime should continue to receive `ModelRequest(messages=..., request_config=...)` and should not know whether an assistant message was rendered with extra inline reasoning text or not.
+
+### Config shape
+
+Put the mode under `agent`, not `runtime`, because this is a transcript policy owned by the agent:
+
+```yaml
+- id: "openai-gpt-5-4-2026-03-05-responses-analysis"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+    analysis_mode: true
+
+  runtime:
+    sdk: "openai-python"
+    api: "responses"
+    state: "manual_rolling"
+
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_output_tokens: 128_000
+    reasoning:
+      effort: "high"
+      summary: "auto"
+
+  pricing:
+    input: 2.50
+    output: 15.00
+```
+
+Notes:
+
+- `agent.analysis_mode: true` gates all replay behavior.
+- The XML replay format is hard-coded in agent code for the first cut. If this mode needs more options later, `analysis_mode` can be expanded from a boolean to a dict in a separate migration.
+- `request.reasoning.summary` still belongs under `request` because it is a provider/API request knob, not an agent policy. For Responses configs, set it when you want `ModelResponse.reasoning_text` to be populated from reasoning summaries.
+- Existing non-analysis configs should keep their current behavior and do not need this `agent.analysis_mode` section.
+
+### Conversation storage shape
+
+Keep `self.conversation` as the canonical transcript of plain `{"role", "content"}` messages.
+
+In normal mode, assistant turns stay as plain final-action text:
+
+```python
+{"role": "assistant", "content": "MOVE_LEFT"}
+```
+
+In analysis mode, assistant turns should store the replay-ready XML block directly in `content`:
+
+```python
+{
+    "role": "assistant",
+    "content": """
+<reasoning_summary>
+I compared the reachable cells and chose the left move because ...
+</reasoning_summary>
+
+MOVE_LEFT
+""",
+}
+```
+
+User and system turns stay unchanged:
+
+```python
+{"role": "system", "content": "..."}
+{"role": "user", "content": "..."}
+```
+
+Why this shape:
+
+- it preserves the current one-user / one-assistant turn structure
+- it keeps all replay text in the assistant message `content` field exactly where the model will see it
+- it keeps trimming logic much simpler than inserting a second synthetic assistant message
+- it keeps `ModelRequest` and adapter code stable for the first cut
+
+### Outbound prompt rendering
+
+Add an agent-owned helper that formats the **assistant turn content** at append time.
+
+In normal mode:
+
+- assistant turns are appended as plain `model_response.output_text`
+
+In analysis replay mode:
+
+- if `model_response.reasoning_text` is non-empty, the appended assistant turn's `content` is rendered with a hard-coded XML `<reasoning_summary>` block followed by the raw final assistant output text
+- if no reasoning summary is available, append the plain action/output text so the turn remains compact and readable
+
+```text
+<reasoning_summary>
+<saved reasoning summary text>
+</reasoning_summary>
+
+<original assistant output text>
+```
+
+This format is intentionally simple and explicit. It gives the model a stable distinction between "prior reasoning summary" and "prior final action" while still storing everything in one assistant `content` field.
+
+User turns remain unchanged in both modes.
+
+System turns should be selected by an agent-owned helper based on `analysis_mode`:
+
+- in normal mode, use the current baseline system prompt unchanged
+- in analysis mode, use a slightly more helper-oriented system prompt that tells the model to treat
+  replayed `<reasoning_summary>` blocks as compact prior-turn context and then produce the next
+  action normally
+
+The first implementation can keep this as a hard-coded branch in agent code rather than introducing
+a new system-prompt config schema.
+
+### Where to inject this in code
+
+Recommended implementation points:
+
+- Parse `agent.analysis_mode` in `BenchmarkingAgent.__init__()` from the loaded config.
+- Add a helper such as `_build_system_prompt()` that returns either the current baseline system
+  prompt or the analysis-mode helper prompt depending on `self.analysis_mode`.
+- Add a helper such as `_build_assistant_turn_content(output_text, reasoning_text)` that returns either plain action text or the XML replay block depending on the analysis-mode config.
+- Change assistant appends in `BenchmarkingAgent.choose_action()` so the canonical assistant turn stores `content = _build_assistant_turn_content(model_response.output_text, model_response.reasoning_text)`.
+- Keep `_build_model_request()` mostly unchanged apart from routing the system prompt through
+  `_build_system_prompt()`: it can continue to convert `self.conversation` into `Message` objects
+  because assistant `content` is already replay-ready in analysis mode.
+- In `choose_action()`, save `StepRecord.messages_sent` from the outbound `ModelRequest.messages` that was actually used for the successful attempt, not from `self.conversation` after appending the current assistant turn.
+
+That final logging detail matters: `messages_sent` should reflect the exact transcript sent to the model on that step, while the newly appended current assistant message becomes part of the transcript for the next step.
+
+### Trimming behavior
+
+Keep the existing "trim oldest user/assistant pair" strategy and preserve one assistant turn per user turn.
+
+Do not insert separate synthetic reasoning messages into `self.conversation` for the first cut. A separate message would make `_trim_oldest_turn()` more fragile because it currently assumes the oldest removable turn starts at a `user` message and includes at most the immediately following `assistant` message.
+
+Because replay text is stored directly in assistant `content`, the current context estimator already counts replayed reasoning text as long as it keeps summing `message["content"]`. That makes this approach safer than storing reasoning in a separate sidecar field that token estimation could accidentally ignore.
+
+### Recording and observability
+
+Target behavior for step logs:
+
+- `messages_sent` should show the exact rendered transcript sent to the model on that step.
+- Prior assistant turns in analysis mode should visibly include the injected reasoning summary block before the final action.
+- `assistant_response` should remain the raw final assistant output for the current step.
+- `reasoning` should remain the raw reasoning summary extracted from the current step response.
+
+This gives you both:
+
+- the exact replay prompt that the model saw
+- the newly produced reasoning summary and action for the current step
+
+### Non-goals for the first implementation
+
+Do not include these in the first cut:
+
+- `previous_response_id` / API-managed continuation
+- native replay of Responses `reasoning` output items
+- encrypted reasoning carryover
+- multiple synthetic assistant messages per turn
+- runtime-adapter awareness of analysis mode
+
+The goal is strictly text-level replay of saved human-readable reasoning summaries as part of agent-owned manual rolling context.
+
+## High-Level Plan
+
+1. Add an agent config section that enables analysis replay mode without affecting current configs.
+2. Define the analysis-mode assistant `content` format so prior reasoning summaries are stored inline before prior assistant actions.
+3. Add an agent-owned helper that routes the system prompt based on `analysis_mode`, returning the
+   baseline prompt in normal mode and a slightly more helper-oriented prompt in analysis mode.
+4. Add an agent-owned helper that builds that XML `content` block at append time only when analysis mode is enabled.
+5. Make step logs record the exact outbound request transcript while keeping canonical conversation storage stable.
+6. Validate that context trimming / token estimation naturally count replayed reasoning text stored in assistant `content`.
+7. Add phase-by-phase tests that prove normal configs are unchanged and analysis configs replay reasoning exactly as intended.
+
+## Phased Checklist
+
+### Phase 1: Define Config and Conversation Semantics
+
+Purpose: introduce an explicit agent-owned analysis mode contract before changing request behavior.
+
+- [x] Add `agent.analysis_mode` to the model-config schema as an optional boolean.
+- [x] Define default behavior when `analysis_mode` is omitted: normal mode, no reasoning replay.
+- [x] Define the canonical assistant turn shape so analysis mode stores the XML replay block directly in `content`.
+- [x] Document the intended rendering format for replayed assistant reasoning.
+- [x] Define the analysis-mode system prompt branch: baseline prompt when `analysis_mode` is false,
+  helper-oriented replay prompt when `analysis_mode` is true.
+- [x] Decide whether analysis mode is introduced through a new dedicated config ID or by editing an existing Responses config. Recommended: new dedicated config IDs only.
+
+Tests for Phase 1:
+
+- [x] Configs without `agent.analysis_mode` still load and behave as normal mode.
+- [x] A config with `agent.analysis_mode: true` loads successfully.
+- [x] A config with invalid `agent.analysis_mode` shape fails with a clear config error.
+- [x] A canonical assistant turn with XML replay content can be represented without breaking existing user/system turn storage.
+
+Exit criteria:
+
+- [x] The config contract and conversation storage contract are explicit and reviewed.
+- [x] No runtime behavior has changed yet for existing configs.
+
+### Phase 2: Add Assistant Turn Formatting for Analysis Replay
+
+Purpose: make analysis-mode assistant turns persist replayed reasoning inline in `content` while preserving normal mode behavior.
+
+- [x] Add an agent helper that formats assistant `content` from `output_text` and `reasoning_text`.
+- [x] In normal mode, append assistant turns exactly as plain `output_text`.
+- [x] In analysis mode, append assistant turns with non-empty reasoning summaries as:
+  - reasoning summary block first
+  - final action block second
+- [x] Use a hard-coded XML `<reasoning_summary>` block followed by the raw final action text, with no nested analysis-mode config dict.
+- [x] Keep user turns unchanged in both modes, preserve the baseline system prompt in normal mode,
+  and route the helper-oriented system prompt only in analysis mode.
+- [x] Keep the runtime adapter contract unchanged.
+- [x] Route the outbound system prompt through an agent helper that selects the baseline or
+  analysis-mode helper prompt based on `analysis_mode`.
+
+Tests for Phase 2:
+
+- [x] Normal mode appends assistant turns as the exact same plain content as today.
+- [x] Analysis mode appends assistant turns with reasoning inline before the final action inside XML tags.
+- [x] Analysis mode appends an assistant turn with missing/empty reasoning as plain content.
+- [x] User turns are unchanged in analysis mode, the system prompt uses the helper branch in
+  analysis mode, and normal mode keeps the baseline system prompt.
+- [x] Responses adapter still receives the expected `instructions` and `input` shape after the rendered transcript is built.
+- [x] Chat Completions adapter still receives the expected `messages` shape after the rendered transcript is built.
+- [x] In analysis mode, the outbound system message uses the helper-oriented replay prompt.
+- [x] In normal mode, the outbound system message remains the current baseline prompt.
+
+Exit criteria:
+
+- [x] The model can be sent replayed reasoning summaries in analysis mode.
+- [x] Existing adapter APIs do not need to know that analysis mode exists.
+
+### Phase 3: Persist Replay-Ready Assistant Content
+
+Purpose: capture each turn's reasoning summary directly in the assistant message `content` that will be replayed on later turns.
+
+- [x] Change assistant-turn appends so `self.conversation` stores XML replay content directly in assistant `content` when analysis mode is enabled.
+- [x] Keep user/system message storage unchanged.
+- [x] Ensure the current assistant action parser still runs against raw `model_response.output_text`, not the XML-wrapped historical replay content.
+- [x] Decide whether to backfill replay formatting only for newly generated turns or also transform pre-existing loaded transcripts. For the current codebase, newly generated turns only is likely enough because conversation state is in-memory during one run.
+
+Tests for Phase 3:
+
+- [x] After one successful model call, the appended assistant turn stores `content = output_text`.
+- [x] After one successful analysis-mode model call with a reasoning summary, the appended assistant turn stores XML replay content with reasoning first and action second.
+- [x] After one successful analysis-mode model call without a reasoning summary, the appended assistant turn stores plain output text and still works.
+- [x] Action parsing still runs against the current response output, not against the replay-rendered historical block.
+
+Exit criteria:
+
+- [x] Prior assistant reasoning summaries are persisted in conversation state for replay on later turns.
+- [x] Current action parsing and ARC stepping behavior remain unchanged.
+
+### Phase 4: Make Step Logging Reflect the Rendered Outbound Transcript
+
+Purpose: ensure recordings show exactly what the model saw, including replayed reasoning blocks.
+
+- [x] Build the outbound `ModelRequest` once per attempt from the rendered transcript.
+- [x] Save `StepRecord.messages_sent` from the rendered request messages, not from raw `self.conversation`.
+- [x] Keep `StepRecord.assistant_response` as the current raw assistant output.
+- [x] Keep `StepRecord.reasoning` as the current raw reasoning summary.
+- [x] Verify that in analysis mode, the recorded transcript shows prior reasoning summaries before prior assistant actions.
+
+Tests for Phase 4:
+
+- [x] In normal mode, `messages_sent` in a step record matches the current plain transcript behavior.
+- [x] In analysis mode, `messages_sent` includes a prior assistant reasoning summary block before the prior assistant action.
+- [x] In analysis mode, the current step's `assistant_response` remains raw action/output text and is not mutated into the replay format.
+- [x] In analysis mode, the current step's `reasoning` remains the extracted summary for that response.
+- [x] Step records still serialize successfully when assistant messages in `messages_sent` include replayed reasoning text.
+
+Exit criteria:
+
+- [x] Recordings provide a faithful audit trail of the prompt text sent to the model in analysis mode.
+
+### Phase 5: Validate Context Trimming and Token Estimation with Replay Content
+
+Purpose: prove that replayed reasoning text stored in assistant `content` is counted and trimmed safely.
+
+- [x] Confirm `_estimate_conversation_tokens()` counts XML replay content because it is stored directly in `message["content"]`.
+- [x] Keep existing trimming semantics: remove the oldest user/assistant pair and preserve the system prompt.
+- [x] Verify that XML replay content on assistant turns is removed when the containing assistant turn is trimmed.
+- [x] Confirm there is no need to rewrite `_trim_oldest_turn()` for the first cut because no separate synthetic reasoning messages are introduced.
+
+Tests for Phase 5:
+
+- [x] Normal mode token estimation remains unchanged for plain transcripts.
+- [x] Analysis mode token estimation includes replayed XML reasoning text stored in assistant `content`.
+- [x] When analysis mode pushes the rendered transcript over the context limit, trimming removes the oldest user/assistant pair and eventually brings the rendered request under the limit.
+- [x] Trimming removes an assistant turn's XML replay content together with that assistant turn.
+- [x] Trimming still preserves the system prompt and current user turn.
+
+Exit criteria:
+
+- [x] Analysis replay cannot silently bypass context limits through replayed reasoning text that is not counted.
+
+### Phase 6: Add Integration and Regression Coverage
+
+Purpose: prove that analysis mode is opt-in, replay works end to end, and normal configs are unaffected.
+
+- [x] Add a dedicated analysis-mode model config ID, likely a Responses config first.
+- [x] Add an integration-style unit test with a fake adapter/model response sequence where turn 2 receives turn 1's replayed reasoning summary inline.
+- [x] Add a regression test proving an existing non-analysis config still sends plain assistant messages.
+- [x] Add serialization checks for recordings produced in analysis mode.
+- [x] Update docs/examples after the behavior is reviewed.
+
+Tests for Phase 6:
+
+- [x] A dedicated analysis config sends plain turn 1 output as the current raw response, appends turn 1 XML replay content to `self.conversation`, and sends turn 2 with turn 1 reasoning replayed inline before turn 1's final action.
+- [x] A non-analysis config with identical model/runtime settings still sends plain prior assistant content only.
+- [x] Responses-path analysis mode and Chat Completions-path analysis mode both behave correctly if both are enabled through separate configs.
+- [x] Recordings from analysis mode contain the rendered prior reasoning block in `messages_sent`.
+- [x] Existing phase 3/4/5 regression tests still pass for normal configs.
+
+Exit criteria:
+
+- [x] Analysis mode is available through an explicit config ID.
+- [x] Normal mode behavior is preserved.
+- [x] End-to-end replay and logging behavior are covered by tests.
+
+## Recommended Implementation Order
+
+1. Add config parsing and defaults for `agent.analysis_mode`.
+2. Add a helper that selects the system prompt based on `analysis_mode`.
+3. Add a helper that formats analysis-mode assistant `content` from `output_text` and `reasoning_text`.
+4. Append replay-ready XML assistant content to `self.conversation` only when analysis mode is enabled.
+5. Save rendered request messages in `StepRecord.messages_sent`.
+6. Validate that context estimation and trimming naturally include replayed XML content.
+7. Add dedicated analysis-mode configs and phase-specific tests.
+
+## Minimum Success Definition
+
+The implementation is done when all of the following are true:
+
+- analysis replay is opt-in under `agent.analysis_mode`
+- system prompt routing is opt-in under `agent.analysis_mode`, with baseline prompting preserved in
+  normal mode and a helper-oriented replay prompt used in analysis mode
+- normal configs produce the same plain transcripts as today
+- analysis-mode assistant turns store prior reasoning summaries inline in assistant `content` before prior assistant action text
+- step recordings show the exact rendered transcript sent to the model
+- context trimming counts replayed reasoning text and removes old turns safely
+- tests cover both analysis and non-analysis behavior

--- a/docs/responses-api-migration.md
+++ b/docs/responses-api-migration.md
@@ -1,0 +1,501 @@
+# Responses API Migration Plan
+
+## Goal
+
+Migrate the benchmarking agent from a hardcoded `chat.completions.create(...)` path to an adapter-driven runtime that can support:
+
+- `chat_completions` as the current baseline
+- `responses` as the first new runtime
+
+This plan keeps the ARC agent logic stable and moves provider/API differences behind a normalized turn contract.
+
+Adapter selection should be config-driven from the runtime tuple:
+
+- `runtime.sdk`
+- `runtime.api`
+
+## Non-Goals For The First Cut
+
+The first implementation should **not** include:
+
+- multi-provider adapter support beyond the current OpenAI client shape
+- API-managed conversation state (`previous_response_id`, `conversation`)
+- background mode, streaming, or webhook polling
+- opaque encrypted continuation-state handoff between turns
+
+The first `responses` implementation should be:
+
+- `sdk: openai-python`
+- `api: responses`
+- `state: manual_rolling`
+
+## Current Constraints
+
+Today the code assumes all of the following:
+
+- model config entries use `name` rather than `id`
+- `call` means kwargs for `chat.completions.create(...)`
+- the agent directly calls the OpenAI SDK
+- the agent directly reads `response.choices[0].message`
+- usage extraction is coupled to chat-completions/OpenRouter-like shapes
+
+That means the first migration step is not "add Responses flags". The first migration step is to make the execution contract explicit.
+
+## Proposed Config Shape
+
+Current config sections should become:
+
+- `id`: stable identifier for selection from CLI and code
+- `agent`: ARC agent behavior
+- `runtime`: execution profile
+- `client`: SDK client construction
+- `request`: adapter-specific request defaults
+- `pricing`: pricing lookup
+
+Example baseline (Chat Completions API):
+
+```yaml
+- id: "openai-gpt-5-4-2026-03-05"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+
+  runtime:
+    sdk: "openai-python"
+    api: "chat_completions"
+    state: "manual_rolling"
+
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_completion_tokens: 128_000
+    reasoning_effort: "low"
+
+  pricing:
+    input: 2.50
+    output: 15.00
+```
+
+Example new runtime (Responses API):
+
+```yaml
+- id: "openai-gpt-5-4-2026-03-05-responses"
+  agent:
+    MAX_ACTIONS_BASELINE_MULTIPLIER: 5.0
+    MAX_CONTEXT_LENGTH: 175_000
+
+  runtime:
+    sdk: "openai-python"
+    api: "responses"
+    state: "manual_rolling"
+
+  client:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+
+  request:
+    model: "gpt-5.4-2026-03-05"
+    max_output_tokens: 128_000
+    reasoning:
+      effort: "low"
+
+  pricing:
+    input: 2.50
+    output: 15.00
+```
+
+## Proposed Normalized Contracts
+
+The first implementation should keep these contracts as small as possible. The real system is:
+
+- the agent owns one conversation history
+- for V1, that history uses `runtime.state == "manual_rolling"`
+- the agent decides which messages to send on a given turn
+- the agent sends the full sliced transcript on each turn instead of relying on API-managed continuation state
+- the runtime adapter sends those messages to the model
+- the runtime adapter normalizes the model output
+- the agent appends the assistant response back into history
+
+### Message
+
+```python
+Message(
+    role: Literal["system", "user", "assistant"],
+    content: str,
+)
+```
+
+Purpose:
+
+- represent one transcript item in a runtime-neutral way
+- keep the normalized role set to `system`, `user`, and `assistant`
+- let each adapter map `system` to the provider-specific instruction channel (`instructions`, `system`, etc.)
+
+### ModelRequest
+
+This is the request object built by the ARC agent and sent to the runtime adapter.
+
+```python
+ModelRequest(
+    messages: list[Message],
+    request_config: dict[str, Any],
+)
+```
+
+Purpose:
+
+- represent the exact slice of conversation history being sent on one model call
+- carry the adapter-specific request kwargs exactly as configured
+
+Notes:
+
+- level and available actions remain embedded in the rendered user message
+- the agent decides how to construct and trim those messages
+- `request_config` includes `model` and the rest of the per-call kwargs from YAML
+
+### NormalizedUsage
+
+```python
+NormalizedUsage(
+    input_tokens: int,
+    output_tokens: int,
+    total_tokens: int,
+    reasoning_tokens: int = 0,
+    cached_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cost: float = 0.0,
+    cost_details: dict[str, float] = {},
+)
+```
+
+### ModelResponse
+
+This is the only result shape the ARC agent should depend on.
+
+```python
+ModelResponse(
+    output_text: str,
+    reasoning_text: str | None,
+    usage: NormalizedUsage,
+    raw_response: Any | None,
+)
+```
+
+Notes:
+
+- the ARC-facing action metadata schema remains the payload sent through the environment
+- that metadata schema is **not** the adapter boundary
+- the ARC-facing metadata payload should be built from `ModelResponse`
+- `reasoning_text` means human-readable reasoning summary/text only
+- do **not** overload `reasoning_text` with opaque encrypted continuation blobs
+- if a future runtime needs to pass opaque continuation state across manual stateless turns, add a dedicated adapter-state field instead of stuffing that data into transcript text
+
+## Adapter Boundary
+
+Create one runtime adapter interface:
+
+```python
+class ModelRuntimeAdapter(Protocol):
+    def invoke(self, request: ModelRequest) -> ModelResponse: ...
+```
+
+First implementations:
+
+- `OpenAIChatCompletionsAdapter`
+- `OpenAIResponsesAdapter`
+
+Dispatch and validation should use `(runtime.sdk, runtime.api)` as the adapter key.
+
+For V1, both adapters should require `runtime.state == "manual_rolling"`.
+
+Responsibilities:
+
+### Agent-owned
+
+- system prompt construction
+- conversation history
+- message slicing per turn
+- frame rendering
+- context trimming
+- retry policy
+- action parsing
+- ARC-facing metadata payload construction
+
+### Adapter-owned
+
+- request translation
+- provider-specific mapping from normalized message roles into the target API request shape
+- raw SDK invocation
+- response normalization
+- usage extraction
+- request-config interpretation
+
+## Required Naming Cleanup
+
+Before or during migration, rename config identity terminology to be explicit:
+
+- config entry field: `name` -> `id`
+- user-facing variable naming: `config_name` -> `config_id`
+
+Reason:
+
+- the config selector is not a display name
+- the CLI and loader semantics are identifier-based
+- future migrations will be easier if config identity is explicit everywhere
+
+## Cross-Field Validation Rules
+
+The config loader should validate these rules:
+
+- `runtime.sdk` is required
+- `runtime.api` is required
+- `runtime.state` is required
+
+Adapter-compatibility rules:
+
+- if `(runtime.sdk, runtime.api) == ("openai-python", "chat_completions")`, validate chat-completions request fields
+- if `(runtime.sdk, runtime.api) == ("openai-python", "responses")`, validate responses request fields
+- for V1, reject any runtime where `runtime.state != "manual_rolling"`
+- reject unsupported `(runtime.sdk, runtime.api)` pairs with a clear config error
+
+## Phased Checklist
+
+Use this section as the execution plan. Complete each phase in order. Do not start the next phase until the current phase exit criteria are satisfied.
+
+### Phase 0: Freeze The Current Baseline
+
+Purpose: capture current behavior before changing structure.
+
+- [x] Add or tighten tests around current config loading
+- [x] Add or tighten tests around current chat-completions result parsing
+- [x] Document the current assumptions in tests
+
+Tests to add and pass: **6**
+
+- [x] Test 0.1: model config list returns all current config identifiers
+- [x] Test 0.2: missing config raises a clear config-not-found error
+- [x] Test 0.3: missing `client.api_key_env` raises a clear error
+- [x] Test 0.4: current chat-completions usage extraction maps prompt/completion/total tokens correctly
+- [x] Test 0.5: current assistant text extraction uses the first choice message content
+- [x] Test 0.6: current action metadata payload contains output, reasoning, usage, and cost
+
+Exit criteria:
+
+- [x] All baseline tests pass
+- [x] No behavioral change yet
+
+### Phase 1: Reshape Config Schema
+
+Purpose: introduce explicit config semantics without changing runtime behavior.
+
+- [x] Rename config field `name` to `id`
+- [x] Rename code references from `config_name` terminology to `config_id`
+- [x] Split config sections into `agent`, `runtime`, `client`, `request`, `pricing`
+- [x] Keep runtime execution still wired to current chat-completions behavior
+
+Tests to add and pass: **10**
+
+- [x] Test 1.1: config loader reads `id` successfully
+- [x] Test 1.2: config loader rejects entries missing `id`
+- [x] Test 1.3: config loader rejects duplicate `id` values
+- [x] Test 1.4: `list_model_config_ids()` returns `id` values, not `name`
+- [x] Test 1.5: config lookup by `config_id` succeeds
+- [x] Test 1.6: config lookup by missing `config_id` fails with available IDs listed
+- [x] Test 1.7: `runtime` section is required
+- [x] Test 1.8: `client` section is required
+- [x] Test 1.9: `request` section is required
+- [x] Test 1.10: legacy `name`-only entry fails clearly or is explicitly migration-handled, depending on chosen strategy
+
+Exit criteria:
+
+- [x] Code selects configs by `config_id`
+- [x] Config schema is explicit
+- [x] Runtime behavior remains unchanged
+
+### Phase 2: Introduce Normalized Turn Contracts
+
+Purpose: make the agent depend on one internal request/response contract.
+
+- [x] Add `Message`
+- [x] Add `ModelRequest`
+- [x] Add `NormalizedUsage`
+- [x] Add `ModelResponse`
+- [x] Add translation from `ModelResponse` to the ARC-facing metadata schema
+- [x] Keep chat-completions as the only implemented runtime path for now
+
+Tests to add and pass: **9**
+
+- [x] Test 2.1: `ModelRequest` validates required fields
+- [x] Test 2.2: `ModelResponse` validates required fields
+- [x] Test 2.3: normalized usage defaults to zeros
+- [x] Test 2.4: normalized usage supports reasoning and cache token details
+- [x] Test 2.5: `ModelResponse` with empty output text is allowed or rejected according to the chosen contract
+- [x] Test 2.6: ARC-facing metadata projection from normalized result maps output correctly
+- [x] Test 2.7: ARC-facing metadata projection maps reasoning correctly
+- [x] Test 2.8: ARC-facing metadata projection maps usage correctly
+- [x] Test 2.9: ARC-facing metadata projection maps pricing-derived cost correctly
+
+Exit criteria:
+
+- [x] The agent consumes only normalized results
+- [x] No raw SDK response shape is referenced outside runtime translation code
+
+### Phase 3: Introduce Adapter Interface And Move Chat Completions Behind It
+
+Purpose: move the existing chat-completions path behind the adapter boundary.
+
+- [x] Add `ModelRuntimeAdapter`
+- [x] Add `OpenAIChatCompletionsAdapter`
+- [x] Add adapter selection keyed by `(runtime.sdk, runtime.api)`
+- [x] Move chat request translation into adapter
+- [x] Move chat response normalization into adapter
+- [x] Validate that V1 adapter routes only run with `runtime.state == "manual_rolling"`
+- [x] Keep agent retries and parsing unchanged
+
+Tests to add and pass: **13**
+
+- [x] Test 3.1: agent builds `ModelRequest` correctly from conversation state
+- [x] Test 3.2: agent slices messages correctly for the outbound request
+- [x] Test 3.3: chat adapter translates request conversation into chat messages correctly
+- [x] Test 3.4: chat adapter passes through request-config kwargs correctly, including `model`
+- [x] Test 3.5: chat adapter returns normalized assistant text correctly
+- [x] Test 3.6: chat adapter returns normalized reasoning text correctly
+- [x] Test 3.7: chat adapter normalizes usage correctly
+- [x] Test 3.8: empty choices response raises the expected empty-response error
+- [x] Test 3.9: unparseable assistant response still retries at the agent layer
+- [x] Test 3.10: current chat path remains behaviorally equivalent to baseline tests
+- [x] Test 3.11: current chat path still produces the ARC-facing metadata payload from normalized responses
+- [x] Test 3.12: adapter dispatch selects the chat adapter from `(runtime.sdk, runtime.api)`
+- [x] Test 3.13: unsupported `runtime.state` fails clearly for the chat route
+
+Exit criteria:
+
+- [x] Current chat-completions path is fully adapter-based
+- [x] The agent no longer directly calls `client.chat.completions.create(...)`
+
+### Phase 4: Add OpenAI Responses Adapter
+
+Purpose: add the first `responses` runtime with the smallest possible behavioral delta.
+
+- [x] Add `OpenAIResponsesAdapter`
+- [x] Support `runtime.api == "responses"`
+- [x] Convert agent-managed manual rolling message history into responses input format
+- [x] Map the first `system` message into Responses `instructions` and the remaining turn history into `input`
+- [x] Do not send `previous_response_id` or `conversation` in the V1 manual rolling route
+- [x] Normalize responses output into `ModelResponse`
+
+Tests to add and pass: **15**
+
+- [x] Test 4.1: config validation accepts `runtime.api == "responses"`
+- [x] Test 4.2: responses adapter translates system/user/assistant conversation correctly
+- [x] Test 4.3: responses adapter passes request-config kwargs correctly, including `model`
+- [x] Test 4.4: responses adapter passes request reasoning config correctly
+- [x] Test 4.5: responses adapter extracts assistant text correctly from responses output
+- [x] Test 4.6: responses adapter extracts human-readable reasoning summary/text correctly if present
+- [x] Test 4.7: responses adapter normalizes usage fields correctly
+- [x] Test 4.8: responses adapter handles empty or malformed output with the expected error
+- [x] Test 4.9: agent can parse an action from a normalized responses result exactly as it does for chat
+- [x] Test 4.10: responses path still produces the ARC-facing metadata payload from normalized responses
+- [x] Test 4.11: responses config works with the same agent-owned trimming strategy
+- [x] Test 4.12: config listing supports mixed `chat_completions` and `responses` configs
+- [x] Test 4.13: responses adapter maps the first `system` message into `instructions`
+- [x] Test 4.14: responses adapter sends remaining user/assistant turns in `input`
+- [x] Test 4.15: responses adapter omits `previous_response_id` and `conversation` for `runtime.state == "manual_rolling"`
+
+Exit criteria:
+
+- [x] Both `chat_completions` and `responses` work through the same adapter boundary
+
+### Phase 5: Regression And Parity Validation
+
+Purpose: validate that the new architecture did not change core agent behavior unexpectedly.
+
+- [x] Add parity-oriented tests
+- [x] Run controlled comparisons between chat and responses configs
+
+Tests to add and pass: **8**
+
+- [x] Test 5.1: the same synthetic normalized output yields the same parsed action regardless of runtime
+- [x] Test 5.2: ARC-facing metadata generated from chat and responses normalized results has the same schema
+- [x] Test 5.3: usage totals remain internally consistent for chat results
+- [x] Test 5.4: usage totals remain internally consistent for responses results
+- [x] Test 5.5: recordings still serialize successfully for chat runs
+- [x] Test 5.6: recordings still serialize successfully for responses runs
+- [x] Test 5.7: config listing still works with mixed chat and responses configs
+- [x] Test 5.8: CLI validation still surfaces missing API key errors correctly for both config types
+
+Exit criteria:
+
+- [x] No regression in chat support
+- [x] Responses support is integrated behind the same contract
+- [x] The full local test suite runs cleanly end to end
+
+### Phase 6: CI And GitHub Actions
+
+Purpose: make the test plan enforceable on every change.
+
+- [ ] Add a GitHub Actions workflow that installs dependencies and runs the full test suite
+- [ ] Configure the workflow to run on pull requests and pushes to the main development branch
+- [ ] Make the workflow fail on any test failure
+- [ ] Document the workflow as the required validation path for future runtime work
+
+Tests to add and pass: **3**
+
+- [ ] Test 6.1: the GitHub Actions workflow installs the project successfully
+- [ ] Test 6.2: the GitHub Actions workflow runs the full test suite successfully
+- [ ] Test 6.3: the GitHub Actions workflow is triggered for the intended GitHub events
+
+Exit criteria:
+
+- [ ] A GitHub Actions workflow exists for the full test suite
+- [ ] The workflow is suitable to gate future runtime changes
+
+### Overall Done Criteria
+
+- [ ] Configs are selected by `config_id`
+- [ ] Runtime selection is explicit via `runtime`
+- [ ] The agent depends only on normalized model responses
+- [ ] The ARC-facing metadata schema is still emitted for the ARC environment
+- [ ] Existing chat-completions support still works
+- [ ] Responses support works via the same agent-managed message history model
+- [ ] The full local test suite passes
+- [ ] GitHub Actions is set up to run the full test suite automatically
+
+## Recommended Test Mix
+
+For the phases above, the test mix should be:
+
+- unit tests for config loading and validation
+- unit tests for request translation and response normalization
+- unit tests for action metadata projection
+- unit tests for retry and empty-response behavior
+- a small number of integration-like tests using stubbed SDK responses
+
+Avoid live API tests for the first migration unless they are explicitly separated and optional.
+
+## Recommended Implementation Order
+
+1. freeze baseline behavior with tests
+2. rename `name` to `id` and `config_name` to `config_id`
+3. introduce explicit config sections
+4. introduce normalized turn contracts
+5. move chat-completions behind adapter boundary
+6. add responses adapter
+7. run parity/regression pass and the full local test suite
+8. add GitHub Actions coverage for the full test suite
+
+## Minimum Success Definition
+
+The migration is successful when:
+
+- configs are selected by `config_id`
+- runtime selection is explicit via `runtime`
+- the agent depends only on normalized model responses
+- the ARC-facing metadata schema is still emitted for the ARC environment
+- existing chat-completions support still works
+- responses support works via the same agent-managed message history model
+- the full local test suite passes
+- GitHub Actions runs the full test suite automatically

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import requests
 
 from benchmarking import BenchmarkingAgent, Swarm
+from benchmarking.cli_list import print_requested_resource_lists
 from benchmarking.model_config import get_model_config, list_model_config_ids
 
 logger = logging.getLogger()
@@ -89,27 +90,27 @@ def fetch_available_games(root_url: str) -> list[str]:
         return []
 
 
-def validate_required_model_api_key(config_name: Optional[str]) -> None:
-    selected_config = config_name or BenchmarkingAgent.MODEL_CONFIG_ID
-    entry = get_model_config(selected_config)
+def validate_required_model_api_key(config_id: Optional[str]) -> None:
+    selected_config_id = config_id or BenchmarkingAgent.MODEL_CONFIG_ID
+    entry = get_model_config(selected_config_id)
 
     client_cfg = entry.get("client", {})
     if not isinstance(client_cfg, dict):
         raise ValueError(
-            f"Model config '{selected_config}' is missing client configuration."
+            f"Model config '{selected_config_id}' is missing client configuration."
         )
 
     api_key_env = str(client_cfg.get("api_key_env", "")).strip()
     if not api_key_env:
         raise ValueError(
-            f"Model config '{selected_config}' is missing client.api_key_env."
+            f"Model config '{selected_config_id}' is missing client.api_key_env."
         )
 
     api_key = os.environ.get(api_key_env, "").strip()
     if not api_key:
         raise ValueError(
             f"No {api_key_env} set. "
-            f"The selected model config '{selected_config}' requires "
+            f"The selected model config '{selected_config_id}' requires "
             f"the {api_key_env} environment variable to be set in your .env file."
         )
 
@@ -146,30 +147,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="List available model config IDs and exit.",
     )
     return parser
-
-
-def maybe_handle_list_requests(args: argparse.Namespace) -> bool:
-    requested_lists: list[tuple[str, list[str]]] = []
-
-    if args.list_configs:
-        requested_lists.append(("Configs", list_model_config_ids()))
-    if args.list_games:
-        requested_lists.append(("Games", fetch_available_games(ROOT_URL)))
-
-    if not requested_lists:
-        return False
-
-    for index, (title, values) in enumerate(requested_lists):
-        if index > 0:
-            print()
-        print(f"{title}:")
-        for value in sorted(values):
-            if title != "Games":
-                print("-", value)
-            else:
-                print("-", value.split("-")[0])
-
-    return True
 
 
 def run_agent(swarm: Swarm) -> None:
@@ -224,7 +201,11 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
-    if maybe_handle_list_requests(args):
+    if print_requested_resource_lists(
+        args,
+        root_url=ROOT_URL,
+        fetch_available_games=fetch_available_games,
+    ):
         return
 
     try:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,0 +1,109 @@
+from arcengine import FrameData, GameAction, GameState
+import pytest
+
+from benchmarking.base import Agent
+
+
+class _FakeEnv:
+    def __init__(self, observation_space: FrameData, step_frame: FrameData) -> None:
+        self.observation_space = observation_space
+        self.step_frame = step_frame
+        self.actions: list[GameAction] = []
+        self.reasonings: list[dict] = []
+
+    def step(
+        self,
+        action: GameAction,
+        data: dict,
+        reasoning: dict,
+    ) -> FrameData:
+        self.actions.append(action)
+        self.reasonings.append(reasoning)
+        return self.step_frame
+
+
+class _TestAgent(Agent):
+    MAX_ACTIONS = 0
+
+    def __init__(self, arc_env: _FakeEnv) -> None:
+        super().__init__(
+            card_id="card-1",
+            game_id="game-1",
+            agent_name="test-agent",
+            ROOT_URL="https://example.com",
+            record=False,
+            arc_env=arc_env,
+        )
+        self.choose_action_calls: list[FrameData] = []
+        self.forced_observations: list[tuple[GameState, GameAction]] = []
+
+    def _convert_raw_frame_data(self, raw):  # noqa: ANN001
+        return raw
+
+    def is_done(self, frames: list[FrameData], latest_frame: FrameData) -> bool:
+        return False
+
+    def choose_action(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+    ) -> GameAction:
+        self.choose_action_calls.append(latest_frame)
+        return GameAction.ACTION1
+
+    def _record_forced_action_observation(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+        forced_action: GameAction,
+    ) -> None:
+        self.forced_observations.append((latest_frame.state, forced_action))
+
+
+def _frame(state: GameState) -> FrameData:
+    return FrameData(
+        frame=[[[0]]],
+        state=state,
+        levels_completed=0,
+        available_actions=[GameAction.ACTION1.value],
+    )
+
+
+@pytest.mark.unit
+class TestAgentForcedReset:
+    @pytest.mark.parametrize(
+        "state",
+        [
+            GameState.GAME_OVER,
+            GameState.NOT_PLAYED,
+        ],
+    )
+    def test_main_forces_reset_for_terminal_states_before_choose_action(self, state):
+        arc_env = _FakeEnv(
+            observation_space=_frame(state),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _TestAgent(arc_env)
+
+        agent.main()
+
+        assert agent.choose_action_calls == []
+        assert agent.forced_observations == [(state, GameAction.RESET)]
+        assert arc_env.actions == [GameAction.RESET]
+        assert len(agent.frames) == 2
+        assert agent.frames[-1].state == GameState.NOT_FINISHED
+
+    def test_main_uses_choose_action_for_non_terminal_state(self):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _TestAgent(arc_env)
+
+        agent.main()
+
+        assert [frame.state for frame in agent.choose_action_calls] == [
+            GameState.NOT_FINISHED,
+        ]
+        assert agent.forced_observations == []
+        assert arc_env.actions == [GameAction.ACTION1]

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -1,0 +1,770 @@
+from types import SimpleNamespace
+
+from arcengine import FrameData, GameAction, GameState
+import pytest
+
+from benchmarking.agent import BenchmarkingAgent
+from benchmarking.runtime_adapters import (
+    OpenAIChatCompletionsAdapter,
+    OpenAIResponsesAdapter,
+)
+from benchmarking.runtime_models import (
+    Message,
+    ModelRequest,
+    ModelResponse,
+    NormalizedUsage,
+)
+
+
+class _FakeAdapter:
+    def __init__(self, responses: list[ModelResponse]) -> None:
+        self._responses = responses
+        self.requests: list[ModelRequest] = []
+
+    def invoke(self, request: ModelRequest) -> ModelResponse:
+        self.requests.append(request)
+        return self._responses.pop(0)
+
+
+class _FakeChatCompletions:
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def create(self, **_kwargs: object) -> object:
+        return self._response
+
+
+class _FakeResponses:
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def create(self, **_kwargs: object) -> object:
+        return self._response
+
+
+class _FakeChatClient:
+    def __init__(self, response: object) -> None:
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions(response))
+
+
+class _FakeResponsesClient:
+    def __init__(self, response: object) -> None:
+        self.responses = _FakeResponses(response)
+
+
+def _agent_for_request_kwargs(request_kwargs: dict) -> BenchmarkingAgent:
+    agent = BenchmarkingAgent.__new__(BenchmarkingAgent)
+    agent.conversation = []
+    agent._request_kwargs = request_kwargs
+    agent.MAX_CONTEXT_LENGTH = 1_000
+    agent.ESTIMATED_CHARS_PER_TOKEN = 1.0
+    agent.MAX_RETRIES = 2
+    agent.analysis_mode = False
+    agent.token_counter = 0
+    return agent
+
+
+def _agent_for_choose_action(
+    *,
+    analysis_mode: bool,
+    responses: list[ModelResponse],
+) -> BenchmarkingAgent:
+    agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+    agent.analysis_mode = analysis_mode
+    agent._adapter = _FakeAdapter(responses)
+    agent.MODEL = "gpt-5.4"
+    agent._pricing = {}
+    agent.step_counter = 0
+    agent._level_action_budgets = []
+    agent._level_action_counter = 0
+    agent._last_levels_completed = 0
+    agent._level_just_advanced = False
+    agent.action_counter = 0
+    agent._previous_action = None
+    agent.MAX_ANIMATION_FRAMES = 7
+    agent._saved_steps = []
+    agent._save_step = agent._saved_steps.append
+    return agent
+
+
+def _playable_frame() -> FrameData:
+    return FrameData(
+        frame=[[[0, 1], [1, 0]]],
+        state=GameState.NOT_FINISHED,
+        levels_completed=0,
+        available_actions=[GameAction.ACTION1.value],
+    )
+
+
+def _terminal_frame(state: GameState) -> FrameData:
+    return FrameData(
+        frame=[[[3, 3], [3, 3]]],
+        state=state,
+        levels_completed=0,
+        available_actions=[GameAction.ACTION1.value],
+    )
+
+
+def _chat_response(text: str = "RESET") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=text,
+                    reasoning="restart",
+                )
+            )
+        ],
+        usage=SimpleNamespace(total_tokens=6),
+    )
+
+
+def _responses_response(text: str = "RESET") -> SimpleNamespace:
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                summary=[SimpleNamespace(text="restart")],
+                content=[],
+            ),
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            ),
+        ],
+        usage=SimpleNamespace(total_tokens=6),
+    )
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentModelRequests:
+    def test_build_system_prompt_uses_baseline_prompt_in_normal_mode(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        system_prompt = agent._build_system_prompt()
+
+        assert "You are playing a game. Your goal is to win." in system_prompt
+        assert "<reasoning_summary>" not in system_prompt
+        assert "compact helper context" not in system_prompt
+
+    def test_build_system_prompt_uses_helper_prompt_in_analysis_mode(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+
+        system_prompt = agent._build_system_prompt()
+
+        assert "You are playing a game. Your goal is to win." in system_prompt
+        assert "<reasoning_summary>" in system_prompt
+        assert "compact helper context" in system_prompt
+
+    def test_build_assistant_turn_content_returns_plain_output_in_normal_mode(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        assert (
+            agent._build_assistant_turn_content("RESET", "restart because blocked")
+            == "RESET"
+        )
+
+    def test_build_assistant_turn_content_wraps_reasoning_in_analysis_mode(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+
+        assert agent._build_assistant_turn_content(
+            "RESET",
+            "restart because blocked",
+        ) == (
+            "<reasoning_summary>\n"
+            "restart because blocked\n"
+            "</reasoning_summary>\n\n"
+            "RESET\n"
+        )
+
+    @pytest.mark.parametrize("reasoning_text", [None, ""])
+    def test_build_assistant_turn_content_returns_plain_output_without_reasoning(
+        self,
+        reasoning_text,
+    ):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+
+        assert agent._build_assistant_turn_content("RESET", reasoning_text) == "RESET"
+
+    def test_builds_model_request_from_conversation_state(self):
+        agent = _agent_for_request_kwargs(
+            {"model": "gpt-5.4", "max_completion_tokens": 128}
+        )
+        agent.conversation = [
+            {"role": "system", "content": "You are playing a game."},
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": "RESET"},
+        ]
+
+        model_request = agent._build_model_request()
+
+        assert model_request == ModelRequest(
+            messages=[
+                Message(role="system", content="You are playing a game."),
+                Message(role="user", content="frame 1"),
+                Message(role="assistant", content="RESET"),
+            ],
+            request_config={"model": "gpt-5.4", "max_completion_tokens": 128},
+        )
+
+    def test_trimmed_history_is_reflected_in_outbound_request(self):
+        agent = _agent_for_request_kwargs(
+            {"model": "gpt-5.4", "max_completion_tokens": 128}
+        )
+        agent.MAX_CONTEXT_LENGTH = 40
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old-user-turn"},
+            {"role": "assistant", "content": "old-assistant-turn"},
+            {"role": "user", "content": "new-user-turn"},
+        ]
+
+        agent._trim_to_fit_context()
+        model_request = agent._build_model_request()
+
+        assert [message.model_dump() for message in model_request.messages] == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "new-user-turn"},
+        ]
+
+    def test_responses_request_kwargs_use_same_agent_owned_trimming_strategy(self):
+        agent = _agent_for_request_kwargs(
+            {
+                "model": "gpt-5.4",
+                "max_output_tokens": 128,
+                "reasoning": {"effort": "high"},
+            }
+        )
+        agent.MAX_CONTEXT_LENGTH = 40
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old-user-turn"},
+            {"role": "assistant", "content": "old-assistant-turn"},
+            {"role": "user", "content": "new-user-turn"},
+        ]
+
+        agent._trim_to_fit_context()
+        model_request = agent._build_model_request()
+
+        assert model_request == ModelRequest(
+            messages=[
+                Message(role="system", content="system"),
+                Message(role="user", content="new-user-turn"),
+            ],
+            request_config={
+                "model": "gpt-5.4",
+                "max_output_tokens": 128,
+                "reasoning": {"effort": "high"},
+            },
+        )
+
+    def test_build_model_request_preserves_replay_shaped_assistant_content(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+        replay_content = (
+            "<reasoning_summary>\n"
+            "I compared the options and chose reset.\n"
+            "</reasoning_summary>\n\n"
+            "RESET"
+        )
+        agent.conversation = [
+            {"role": "system", "content": "You are playing a game."},
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": replay_content},
+        ]
+
+        model_request = agent._build_model_request()
+
+        assert [message.model_dump() for message in model_request.messages] == [
+            {"role": "system", "content": "You are playing a game."},
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": replay_content},
+        ]
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentRetries:
+    def test_unparseable_assistant_response_retries_until_action_is_parsed(self):
+        agent = _agent_for_request_kwargs(
+            {"model": "gpt-5.4", "max_completion_tokens": 128}
+        )
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        responses = [
+            ModelResponse(
+                output_text="not an action",
+                usage=NormalizedUsage(total_tokens=4),
+            ),
+            ModelResponse(
+                output_text="RESET",
+                usage=NormalizedUsage(total_tokens=6),
+            ),
+        ]
+
+        def fake_call_api(_request: ModelRequest) -> ModelResponse:
+            return responses.pop(0)
+
+        agent._call_api = fake_call_api
+
+        model_response, action, retries, messages_sent = agent._request_with_retries(
+            [GameAction.RESET]
+        )
+
+        assert model_response.output_text == "RESET"
+        assert model_response.usage.total_tokens == 10
+        assert action == GameAction.RESET
+        assert retries == 1
+        assert messages_sent == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        assert agent.token_counter == 10
+
+    def test_normalized_responses_output_parses_action_like_chat_output(self):
+        agent = _agent_for_request_kwargs(
+            {
+                "model": "gpt-5.4",
+                "max_output_tokens": 128,
+                "reasoning": {"effort": "high"},
+            }
+        )
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        agent._adapter = _FakeAdapter(
+            [
+                ModelResponse(
+                    output_text="thinking without a valid action",
+                    reasoning_text="no action yet",
+                    usage=NormalizedUsage(total_tokens=4),
+                ),
+                ModelResponse(
+                    output_text="RESET",
+                    reasoning_text="restart",
+                    usage=NormalizedUsage(total_tokens=6),
+                ),
+            ]
+        )
+
+        model_response, action, retries, messages_sent = agent._request_with_retries(
+            [GameAction.RESET]
+        )
+
+        assert model_response.output_text == "RESET"
+        assert model_response.reasoning_text == "restart"
+        assert model_response.usage.total_tokens == 10
+        assert action == GameAction.RESET
+        assert retries == 1
+        assert messages_sent == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        assert agent.token_counter == 10
+
+    @pytest.mark.parametrize(
+        ("adapter", "request_kwargs"),
+        [
+            (
+                OpenAIChatCompletionsAdapter(_FakeChatClient(_chat_response())),
+                {"model": "gpt-5.4"},
+            ),
+            (
+                OpenAIResponsesAdapter(_FakeResponsesClient(_responses_response())),
+                {"model": "gpt-5.4"},
+            ),
+        ],
+    )
+    def test_chat_and_responses_adapters_yield_same_parsed_action(
+        self,
+        adapter,
+        request_kwargs,
+    ):
+        agent = _agent_for_request_kwargs(request_kwargs)
+        agent.MAX_RETRIES = 0
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        agent._adapter = adapter
+
+        model_response, action, retries, messages_sent = agent._request_with_retries(
+            [GameAction.RESET]
+        )
+
+        assert model_response.output_text == "RESET"
+        assert model_response.reasoning_text == "restart"
+        assert action == GameAction.RESET
+        assert retries == 0
+        assert messages_sent == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentConversationStorage:
+    def test_choose_action_appends_plain_assistant_output_in_normal_mode(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=False,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="choose the first action",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
+        assert agent.conversation[-1] == {
+            "role": "assistant",
+            "content": "ACTION1",
+        }
+        assert agent._saved_steps[0].messages_sent == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(_playable_frame())},
+        ]
+        assert agent._saved_steps[0].assistant_response == "ACTION1"
+        assert agent._saved_steps[0].reasoning == "choose the first action"
+
+    def test_choose_action_appends_replay_xml_assistant_content_in_analysis_mode(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="choose the first action",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
+        assert agent.conversation[-1] == {
+            "role": "assistant",
+            "content": (
+                "<reasoning_summary>\n"
+                "choose the first action\n"
+                "</reasoning_summary>\n\n"
+                "ACTION1\n"
+            ),
+        }
+        assert agent._saved_steps[0].messages_sent == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(_playable_frame())},
+        ]
+        assert agent._saved_steps[0].assistant_response == "ACTION1"
+        assert agent._saved_steps[0].reasoning == "choose the first action"
+
+    def test_choose_action_appends_plain_output_without_reasoning_in_analysis_mode(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text=None,
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
+        assert agent.conversation[-1] == {
+            "role": "assistant",
+            "content": "ACTION1",
+        }
+
+    def test_choose_action_parses_current_raw_output_not_rendered_replay_content(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="ACTION2 would fail here",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+        parsed_inputs = []
+
+        def fake_parse_action(text, available_actions):
+            parsed_inputs.append(text)
+            return GameAction.ACTION1
+
+        agent._parse_action = fake_parse_action
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
+        assert parsed_inputs == ["ACTION1"]
+
+    def test_choose_action_records_prior_replay_content_in_messages_sent_not_current_reply(
+        self,
+    ):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="current turn reasoning",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+        prior_replay_content = (
+            "<reasoning_summary>\n"
+            "prior turn reasoning\n"
+            "</reasoning_summary>\n\n"
+            "ACTION1\n"
+        )
+        agent.conversation = [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": "prior frame"},
+            {"role": "assistant", "content": prior_replay_content},
+        ]
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
+        assert agent._saved_steps[0].messages_sent == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": "prior frame"},
+            {"role": "assistant", "content": prior_replay_content},
+            {"role": "user", "content": agent.build_frame_content(_playable_frame())},
+        ]
+        assert agent._saved_steps[0].assistant_response == "ACTION1"
+        assert agent._saved_steps[0].reasoning == "current turn reasoning"
+        assert agent._saved_steps[0].model_dump()["messages_sent"][2]["content"] == (
+            prior_replay_content
+        )
+
+    def test_resolve_action_records_game_over_frame_before_forced_reset_without_model_call(
+        self,
+    ):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="should not be used",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+        agent.action_counter = 1
+
+        action = agent._resolve_action([], _terminal_frame(GameState.GAME_OVER))
+
+        assert action == GameAction.RESET
+        assert agent._adapter.requests == []
+        assert agent._saved_steps[0].parsed_action == "RESET"
+        assert agent._saved_steps[0].messages_sent == [
+            {
+                "role": "user",
+                "content": agent.build_frame_content(
+                    _terminal_frame(GameState.GAME_OVER)
+                ),
+            }
+        ]
+        assert agent.conversation == agent._saved_steps[0].messages_sent
+
+    def test_resolve_action_for_not_played_forces_reset_without_appending_transcript_frame(
+        self,
+    ):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="should not be used",
+                    usage=NormalizedUsage(total_tokens=9),
+                )
+            ],
+        )
+
+        action = agent._resolve_action([], _terminal_frame(GameState.NOT_PLAYED))
+
+        assert action == GameAction.RESET
+        assert agent._adapter.requests == []
+        assert agent.conversation == []
+        assert agent._saved_steps[0].parsed_action == "RESET"
+        assert agent._saved_steps[0].messages_sent == []
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentContextTrimming:
+    def test_estimate_conversation_tokens_counts_plain_transcript_text(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+            {"role": "assistant", "content": "ACTION1"},
+        ]
+
+        assert agent._estimate_conversation_tokens() == len("systemframeACTION1")
+
+    def test_estimate_conversation_tokens_counts_analysis_replay_xml(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+        replay_content = agent._build_assistant_turn_content(
+            "ACTION1",
+            "reason through the old turn",
+        )
+        agent.conversation = [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": "frame"},
+            {"role": "assistant", "content": replay_content},
+        ]
+
+        assert agent._estimate_conversation_tokens() == sum(
+            len(message["content"]) for message in agent.conversation
+        )
+        assert agent._estimate_conversation_tokens() > len(
+            f"{agent._build_system_prompt()}frameACTION1"
+        )
+
+    def test_trim_to_fit_context_removes_oldest_replay_turn_and_preserves_current_user(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+        old_replay_content = agent._build_assistant_turn_content(
+            "ACTION1",
+            "reasoning that makes the old assistant turn much longer",
+        )
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old-user-turn"},
+            {"role": "assistant", "content": old_replay_content},
+            {"role": "user", "content": "current-user-turn"},
+        ]
+        agent.MAX_CONTEXT_LENGTH = len("systemcurrent-user-turn")
+
+        agent._trim_to_fit_context()
+
+        assert agent.conversation == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "current-user-turn"},
+        ]
+        assert agent._estimate_conversation_tokens() <= agent.MAX_CONTEXT_LENGTH
+
+    def test_trim_oldest_turn_removes_replay_xml_with_its_assistant_message(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        replay_content = (
+            "<reasoning_summary>\n"
+            "prior reasoning\n"
+            "</reasoning_summary>\n\n"
+            "ACTION1\n"
+        )
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old-user-turn"},
+            {"role": "assistant", "content": replay_content},
+            {"role": "user", "content": "current-user-turn"},
+        ]
+
+        assert agent._trim_oldest_turn() is True
+
+        assert agent.conversation == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "current-user-turn"},
+        ]
+        assert replay_content not in [
+            message["content"] for message in agent.conversation
+        ]
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentAnalysisReplayIntegration:
+    def test_analysis_mode_replays_turn_one_reasoning_into_turn_two_messages_sent(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=True,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="inspect the first frame",
+                    usage=NormalizedUsage(total_tokens=9),
+                ),
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="continue the same plan",
+                    usage=NormalizedUsage(total_tokens=11),
+                ),
+            ],
+        )
+
+        first_frame = _playable_frame()
+        second_frame = _playable_frame()
+
+        first_action = agent.choose_action([], first_frame)
+        second_action = agent.choose_action([first_frame], second_frame)
+
+        expected_replay_content = (
+            "<reasoning_summary>\n"
+            "inspect the first frame\n"
+            "</reasoning_summary>\n\n"
+            "ACTION1\n"
+        )
+        assert first_action == GameAction.ACTION1
+        assert second_action == GameAction.ACTION1
+        assert agent.conversation[2] == {
+            "role": "assistant",
+            "content": expected_replay_content,
+        }
+        assert [
+            message.model_dump() for message in agent._adapter.requests[1].messages
+        ] == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(first_frame)},
+            {"role": "assistant", "content": expected_replay_content},
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+        ]
+        assert agent._saved_steps[1].messages_sent == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(first_frame)},
+            {"role": "assistant", "content": expected_replay_content},
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+        ]
+
+    def test_normal_mode_sends_plain_turn_one_assistant_content_into_turn_two(self):
+        agent = _agent_for_choose_action(
+            analysis_mode=False,
+            responses=[
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="inspect the first frame",
+                    usage=NormalizedUsage(total_tokens=9),
+                ),
+                ModelResponse(
+                    output_text="ACTION1",
+                    reasoning_text="continue the same plan",
+                    usage=NormalizedUsage(total_tokens=11),
+                ),
+            ],
+        )
+
+        first_frame = _playable_frame()
+        second_frame = _playable_frame()
+
+        agent.choose_action([], first_frame)
+        agent.choose_action([first_frame], second_frame)
+
+        assert [
+            message.model_dump() for message in agent._adapter.requests[1].messages
+        ] == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(first_frame)},
+            {"role": "assistant", "content": "ACTION1"},
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+        ]

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -768,3 +768,56 @@ class TestBenchmarkingAgentAnalysisReplayIntegration:
             {"role": "assistant", "content": "ACTION1"},
             {"role": "user", "content": agent.build_frame_content(second_frame)},
         ]
+
+
+def _agent_with_env(step_frame: FrameData) -> BenchmarkingAgent:
+    """Reuse _agent_for_choose_action and patch in a minimal arc_env."""
+    agent = _agent_for_choose_action(analysis_mode=False, responses=[])
+    agent.arc_env = SimpleNamespace(step=lambda action, *, data, reasoning: step_frame)
+    agent._convert_raw_frame_data = lambda raw: raw
+    return agent
+
+
+@pytest.mark.unit
+class TestDoubleResetPrevention:
+    def test_do_action_request_sets_previous_action(self):
+        agent = _agent_with_env(_playable_frame())
+
+        agent.do_action_request(GameAction.RESET)
+
+        assert agent._previous_action == GameAction.RESET
+
+    def test_reset_is_not_valid_after_a_reset(self):
+        agent = _agent_with_env(_playable_frame())
+        agent.action_counter = 1
+
+        agent.do_action_request(GameAction.RESET)
+
+        assert agent.is_reset_a_valid_action() is False
+
+    def test_reset_becomes_valid_again_after_a_non_reset_action(self):
+        agent = _agent_with_env(_playable_frame())
+        agent.action_counter = 1
+
+        agent.do_action_request(GameAction.RESET)
+        agent.do_action_request(GameAction.ACTION1)
+
+        assert agent.is_reset_a_valid_action() is True
+
+    def test_get_actions_excludes_reset_after_a_reset(self):
+        agent = _agent_with_env(_playable_frame())
+        agent.action_counter = 1
+
+        agent.do_action_request(GameAction.RESET)
+        actions = agent._get_actions(_playable_frame())
+
+        assert GameAction.RESET not in actions
+
+    def test_get_actions_includes_reset_after_a_non_reset_action(self):
+        agent = _agent_with_env(_playable_frame())
+        agent.action_counter = 1
+
+        agent.do_action_request(GameAction.ACTION1)
+        actions = agent._get_actions(_playable_frame())
+
+        assert GameAction.RESET in actions

--- a/tests/unit/test_cli_list.py
+++ b/tests/unit/test_cli_list.py
@@ -1,0 +1,76 @@
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from benchmarking.cli_list import print_requested_resource_lists
+
+
+def _fetch_games(_root_url: str) -> list[str]:
+    return ["ls20-game-1", "ls21-game-2"]
+
+
+@pytest.mark.unit
+class TestCliList:
+    def test_print_requested_resource_lists_prints_requested_lists(self, capsys):
+        args = Namespace(list_configs=True, list_games=False)
+
+        with patch(
+            "benchmarking.cli_list.list_model_config_ids",
+            return_value=["openai-gpt-5.4-openrouter"],
+        ):
+            handled = print_requested_resource_lists(
+                args,
+                root_url="https://example.com",
+                fetch_available_games=_fetch_games,
+            )
+
+        captured = capsys.readouterr()
+
+        assert handled is True
+        assert captured.out == (
+            "Configs:\n"
+            "- openai-gpt-5.4-openrouter\n"
+        )
+
+    def test_print_requested_resource_lists_prints_games_and_configs_together(
+        self,
+        capsys,
+    ):
+        args = Namespace(list_configs=True, list_games=True)
+
+        with patch(
+            "benchmarking.cli_list.list_model_config_ids",
+            return_value=["openai-gpt-5.4-openrouter"],
+        ):
+            handled = print_requested_resource_lists(
+                args,
+                root_url="https://example.com",
+                fetch_available_games=_fetch_games,
+            )
+
+        captured = capsys.readouterr()
+
+        assert handled is True
+        assert captured.out == (
+            "Configs:\n"
+            "- openai-gpt-5.4-openrouter\n"
+            "\n"
+            "Games:\n"
+            "- ls20\n"
+            "- ls21\n"
+        )
+
+    def test_print_requested_resource_lists_returns_false_when_no_list_flags_are_set(
+        self,
+    ):
+        args = Namespace(list_configs=False, list_games=False)
+
+        assert (
+            print_requested_resource_lists(
+                args,
+                root_url="https://example.com",
+                fetch_available_games=_fetch_games,
+            )
+            is False
+        )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,3 @@
-from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,8 +25,15 @@ class TestMainCliHelpers:
 
         cli_main.validate_required_model_api_key("openai-gpt-5.4-openrouter")
 
-    def test_validate_required_model_api_key_uses_default_config(self, monkeypatch):
+    def test_validate_required_model_api_key_uses_agent_model_config_id_when_config_omitted(
+        self, monkeypatch
+    ):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        monkeypatch.setattr(
+            cli_main.BenchmarkingAgent,
+            "MODEL_CONFIG_ID",
+            "openai-gpt-5.4-openrouter",
+        )
 
         cli_main.validate_required_model_api_key(None)
 
@@ -47,6 +53,42 @@ class TestMainCliHelpers:
         assert "Model config 'does-not-exist' not found" in message
         assert "Available configs:" in message
         assert "openai-gpt-5.4-openrouter" in message
+
+    def test_validate_required_model_api_key_rejects_missing_client_api_key_env(self):
+        with patch(
+            "main.get_model_config",
+            return_value={"client": {}},
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                cli_main.validate_required_model_api_key("missing-api-key-env")
+
+        assert (
+            str(exc_info.value)
+            == "Model config 'missing-api-key-env' is missing client.api_key_env."
+        )
+
+    @pytest.mark.parametrize(
+        "config_id",
+        [
+            "openai-gpt-5-4-2026-03-05",
+            "openai-gpt-5-4-2026-03-05-responses",
+        ],
+    )
+    def test_validate_required_model_api_key_rejects_missing_openai_key_for_chat_and_responses_configs(
+        self,
+        monkeypatch,
+        config_id,
+    ):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError) as exc_info:
+            cli_main.validate_required_model_api_key(config_id)
+
+        assert str(exc_info.value) == (
+            "No OPENAI_API_KEY set. "
+            f"The selected model config '{config_id}' requires "
+            "the OPENAI_API_KEY environment variable to be set in your .env file."
+        )
 
     def test_fetch_available_games_parses_game_ids(self):
         mock_response = MagicMock()
@@ -69,25 +111,3 @@ class TestMainCliHelpers:
             "https://example.com/api/games",
             timeout=10,
         )
-
-    def test_maybe_handle_list_requests_prints_requested_lists(self, capsys):
-        args = Namespace(list_configs=True, list_games=False)
-
-        with patch(
-            "main.list_model_config_ids",
-            return_value=["openai-gpt-5.4-openrouter"],
-        ):
-            handled = cli_main.maybe_handle_list_requests(args)
-
-        captured = capsys.readouterr()
-
-        assert handled is True
-        assert captured.out == (
-            "Configs:\n"
-            "- openai-gpt-5.4-openrouter\n"
-        )
-
-    def test_maybe_handle_list_requests_returns_false_when_unused(self):
-        args = Namespace(list_configs=False, list_games=False)
-
-        assert cli_main.maybe_handle_list_requests(args) is False

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -1,0 +1,313 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+import benchmarking.model_config as model_config
+
+
+def _write_model_configs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configs: list[dict],
+) -> Path:
+    config_path = tmp_path / "model_configs.yaml"
+    config_path.write_text(yaml.safe_dump(configs, sort_keys=False))
+    monkeypatch.setattr(model_config, "MODEL_CONFIG_PATH", config_path)
+    return config_path
+
+
+def _valid_config(
+    config_id: str,
+    *,
+    runtime_api: str = "chat_completions",
+    **overrides: dict,
+) -> dict:
+    config = {
+        "id": config_id,
+        "runtime": {
+            "sdk": "openai-python",
+            "api": runtime_api,
+            "state": "manual_rolling",
+        },
+        "client": {
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+        },
+        "request": {
+            "model": "gpt-5.4-2026-03-05",
+            "max_completion_tokens": 128_000,
+        },
+        "agent": {"MAX_CONTEXT_LENGTH": 175_000},
+        "pricing": {"input": 2.50, "output": 15.00},
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.mark.unit
+class TestModelConfig:
+    def test_load_model_configs_reads_id(self, tmp_path, monkeypatch):
+        _write_model_configs(tmp_path, monkeypatch, [_valid_config("chat-config")])
+
+        configs = model_config.load_model_configs()
+
+        assert configs[0]["id"] == "chat-config"
+
+    def test_load_model_configs_accepts_responses_api(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("responses-config", runtime_api="responses")],
+        )
+
+        configs = model_config.load_model_configs()
+
+        assert configs[0]["runtime"]["api"] == "responses"
+
+    def test_load_model_configs_accepts_boolean_analysis_mode(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "analysis-config",
+                    agent={"MAX_CONTEXT_LENGTH": 175_000, "analysis_mode": True},
+                )
+            ],
+        )
+
+        configs = model_config.load_model_configs()
+
+        assert configs[0]["agent"]["analysis_mode"] is True
+
+    def test_load_model_configs_allows_omitted_analysis_mode(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("normal-config", agent={"MAX_CONTEXT_LENGTH": 175_000})],
+        )
+
+        configs = model_config.load_model_configs()
+
+        assert "analysis_mode" not in configs[0]["agent"]
+
+    def test_load_model_configs_rejects_non_boolean_analysis_mode(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "bad-analysis-config",
+                    agent={"MAX_CONTEXT_LENGTH": 175_000, "analysis_mode": "true"},
+                )
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="agent.analysis_mode must be a boolean",
+        ):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_rejects_non_mapping_agent_section(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("bad-agent-section", agent=True)],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="section 'agent' must be a mapping",
+        ):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_rejects_entries_missing_id(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "runtime": {
+                        "sdk": "openai-python",
+                        "api": "chat_completions",
+                        "state": "manual_rolling",
+                    },
+                    "client": {"api_key_env": "OPENAI_API_KEY"},
+                    "request": {"model": "gpt-5.4"},
+                }
+            ],
+        )
+
+        with pytest.raises(ValueError, match="missing required 'id'"):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_rejects_duplicate_ids(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config("duplicate-id"),
+                _valid_config("duplicate-id"),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="Duplicate model config id 'duplicate-id'"):
+            model_config.load_model_configs()
+
+    def test_list_model_config_ids_returns_id_values_not_name(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("chat-config", name="legacy-display-name")],
+        )
+
+        assert model_config.list_model_config_ids() == ["chat-config"]
+
+    def test_get_model_config_by_id_succeeds(self, tmp_path, monkeypatch):
+        _write_model_configs(tmp_path, monkeypatch, [_valid_config("lookup-success")])
+
+        config = model_config.get_model_config("lookup-success")
+
+        assert config["id"] == "lookup-success"
+        assert config["request"]["model"] == "gpt-5.4-2026-03-05"
+
+    def test_get_model_config_by_missing_id_lists_available_ids(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config_path = _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config("available-a"),
+                _valid_config("available-b"),
+            ],
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            model_config.get_model_config("missing-id")
+
+        message = str(exc_info.value)
+        assert f"Model config 'missing-id' not found in {config_path}" in message
+        assert "Available configs: available-a, available-b" in message
+
+    def test_load_model_configs_requires_runtime_section(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("missing-runtime", runtime=None)],
+        )
+
+        with pytest.raises(ValueError, match="missing required section 'runtime'"):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_requires_client_section(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("missing-client", client=None)],
+        )
+
+        with pytest.raises(ValueError, match="missing required section 'client'"):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_requires_request_section(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [_valid_config("missing-request", request=None)],
+        )
+
+        with pytest.raises(ValueError, match="missing required section 'request'"):
+            model_config.load_model_configs()
+
+    def test_legacy_name_only_entry_fails_clearly(self, tmp_path, monkeypatch):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "name": "legacy-only",
+                    "runtime": {
+                        "sdk": "openai-python",
+                        "api": "chat_completions",
+                        "state": "manual_rolling",
+                    },
+                    "client": {"api_key_env": "OPENAI_API_KEY"},
+                    "request": {"model": "gpt-5.4"},
+                }
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="uses legacy field 'name'. Rename it to 'id'",
+        ):
+            model_config.load_model_configs()
+
+    def test_checked_in_config_ids_include_chat_and_responses_models(self):
+        config_ids = set(model_config.list_model_config_ids())
+
+        assert {
+            "anthropic-opus-4-6",
+            "anthropic-opus-4-6-max-effort",
+            "google-gemini-3-1-pro-preview",
+            "openai-gpt-5-4-2026-03-05",
+            "openai-gpt-5-4-2026-03-05-high",
+            "openai-gpt-5-4-2026-03-05-low",
+            "openai-gpt-5-4-2026-03-05-responses",
+            "openai-gpt-5-4-2026-03-05-responses-analysis",
+            "openai-gpt-5-4-2026-03-05-xhigh",
+            "openai-gpt-5.4-openrouter",
+            "xai-grok-4-20-beta-0309-reasoning",
+        } <= config_ids
+
+    def test_checked_in_analysis_config_enables_reasoning_summary_replay(self):
+        config = model_config.get_model_config(
+            "openai-gpt-5-4-2026-03-05-responses-analysis"
+        )
+
+        assert config["agent"]["analysis_mode"] is True
+        assert config["runtime"]["api"] == "responses"
+        assert config["request"]["reasoning"] == {
+            "effort": "low",
+            "summary": "auto",
+        }
+
+    def test_list_model_config_ids_supports_mixed_chat_and_responses_configs(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config("chat-config", runtime_api="chat_completions"),
+                _valid_config("responses-config", runtime_api="responses"),
+            ],
+        )
+
+        assert model_config.list_model_config_ids() == [
+            "chat-config",
+            "responses-config",
+        ]

--- a/tests/unit/test_recording.py
+++ b/tests/unit/test_recording.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarking.recording import RunRecord, StepRecord, StepUsage
+from benchmarking.runtime_models import ModelResponse, NormalizedUsage
+
+
+def _model_response() -> ModelResponse:
+    return ModelResponse(
+        output_text="RESET",
+        reasoning_text="restart",
+        usage=NormalizedUsage(
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+            reasoning_tokens=3,
+            cached_tokens=5,
+            cache_write_tokens=2,
+            cost=0.42,
+            cost_details={"provider_cost": 0.42},
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestRecordingModels:
+    def test_step_usage_from_response_maps_chat_completion_token_fields(self):
+        response = SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=123,
+                completion_tokens=45,
+                total_tokens=168,
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=7,
+                    cache_write_tokens=3,
+                ),
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=11),
+                model_extra={"cost": 0.75, "cost_details": {"provider_cost": 0.75}},
+            )
+        )
+
+        usage = StepUsage.from_response(response)
+
+        assert usage.prompt_tokens == 123
+        assert usage.completion_tokens == 45
+        assert usage.total_tokens == 168
+        assert usage.cached_tokens == 7
+        assert usage.cache_write_tokens == 3
+        assert usage.reasoning_tokens == 11
+        assert usage.cost == 0.75
+        assert usage.cost_details == {"provider_cost": 0.75}
+
+    @pytest.mark.parametrize(
+        "model_response",
+        [
+            _model_response(),
+            ModelResponse(
+                output_text="RESET",
+                reasoning_text=None,
+                usage=NormalizedUsage(input_tokens=36, output_tokens=87, total_tokens=123),
+            ),
+        ],
+    )
+    def test_step_and_run_records_serialize_successfully(self, model_response):
+        step = StepRecord(
+            step=1,
+            timestamp=datetime.now(timezone.utc),
+            model="gpt-5.4",
+            messages_sent=[{"role": "user", "content": "frame"}],
+            assistant_response=model_response.output_text,
+            reasoning=model_response.reasoning_text,
+            parsed_action="RESET",
+            usage=StepUsage.from_normalized_usage(model_response.usage),
+        )
+        run = RunRecord(
+            run_id="run-id",
+            game_id="game-id",
+            agent_name="agent",
+            model="gpt-5.4",
+            started_at=datetime.now(timezone.utc),
+            total_steps=1,
+            total_usage=step.usage,
+            run_dir="recordings/run-id",
+        )
+
+        step_json = step.model_dump_json()
+        run_json = run.model_dump_json()
+
+        assert '"assistant_response":"RESET"' in step_json
+        assert f'"total_tokens":{model_response.usage.total_tokens}' in run_json

--- a/tests/unit/test_runtime_adapters.py
+++ b/tests/unit/test_runtime_adapters.py
@@ -1,0 +1,521 @@
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarking.exceptions import EmptyResponseError
+from benchmarking.runtime_adapters import (
+    OpenAIChatCompletionsAdapter,
+    OpenAIResponsesAdapter,
+    build_model_runtime_adapter,
+)
+from benchmarking.runtime_models import Message, ModelRequest
+
+
+class _FakeChatCompletions:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+class _FakeResponses:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+class _FakeChatOpenAIClient:
+    def __init__(self, response: object) -> None:
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions(response))
+
+
+class _FakeResponsesOpenAIClient:
+    def __init__(self, response: object) -> None:
+        self.responses = _FakeResponses(response)
+
+
+def _chat_response(
+    *,
+    content: str = "MOVE_LEFT",
+    reasoning: str | None = "because",
+    prompt_tokens: int = 11,
+    completion_tokens: int = 7,
+    total_tokens: int = 18,
+    reasoning_tokens: int = 3,
+    cached_tokens: int = 5,
+    cache_write_tokens: int = 2,
+    cost: float = 0.42,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    reasoning=reasoning,
+                )
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=cached_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+            completion_tokens_details=SimpleNamespace(
+                reasoning_tokens=reasoning_tokens,
+            ),
+            model_extra={"cost": cost, "cost_details": {"provider_cost": cost}},
+        ),
+    )
+
+
+def _responses_output(
+    *,
+    text: str = "MOVE_LEFT",
+    reasoning_summary: str | None = "because",
+    input_tokens: int = 11,
+    output_tokens: int = 7,
+    total_tokens: int = 18,
+    reasoning_tokens: int = 3,
+    cached_tokens: int = 5,
+    cache_write_tokens: int = 2,
+    cost: float = 0.42,
+) -> SimpleNamespace:
+    output = [
+        SimpleNamespace(
+            type="message",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text=text)],
+        )
+    ]
+    if reasoning_summary is not None:
+        output.insert(
+            0,
+            SimpleNamespace(
+                type="reasoning",
+                summary=[SimpleNamespace(text=reasoning_summary)],
+                content=[],
+            ),
+        )
+
+    return SimpleNamespace(
+        output=output,
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=cached_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+            output_tokens_details=SimpleNamespace(
+                reasoning_tokens=reasoning_tokens,
+            ),
+            model_extra={"cost": cost, "cost_details": {"provider_cost": cost}},
+        ),
+    )
+
+
+def _chat_request() -> ModelRequest:
+    return ModelRequest(
+        messages=[
+            Message(role="system", content="You are playing a game."),
+            Message(role="user", content="frame"),
+        ],
+        request_config={"model": "gpt-5.4", "max_completion_tokens": 128},
+    )
+
+
+def _responses_request() -> ModelRequest:
+    return ModelRequest(
+        messages=[
+            Message(role="system", content="You are playing a game."),
+            Message(role="user", content="frame 1"),
+            Message(role="assistant", content="MOVE_LEFT"),
+            Message(role="user", content="frame 2"),
+        ],
+        request_config={"model": "gpt-5.4", "max_output_tokens": 128},
+    )
+
+
+@pytest.mark.unit
+class TestOpenAIChatCompletionsAdapter:
+    def test_translates_request_messages_into_chat_messages(self):
+        client = _FakeChatOpenAIClient(_chat_response())
+        adapter = OpenAIChatCompletionsAdapter(client)
+
+        adapter.invoke(_chat_request())
+
+        assert client.chat.completions.calls == [
+            {
+                "messages": [
+                    {"role": "system", "content": "You are playing a game."},
+                    {"role": "user", "content": "frame"},
+                ],
+                "model": "gpt-5.4",
+                "max_completion_tokens": 128,
+            }
+        ]
+
+    def test_preserves_analysis_mode_prompt_and_replay_content_in_chat_messages(self):
+        client = _FakeChatOpenAIClient(_chat_response())
+        adapter = OpenAIChatCompletionsAdapter(client)
+        replay_content = (
+            "<reasoning_summary>\n"
+            "inspect the top row\n"
+            "</reasoning_summary>\n\n"
+            "MOVE_LEFT"
+        )
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[
+                    Message(
+                        role="system",
+                        content=(
+                            "Use <reasoning_summary> blocks as compact helper context."
+                        ),
+                    ),
+                    Message(role="user", content="frame 1"),
+                    Message(role="assistant", content=replay_content),
+                    Message(role="user", content="frame 2"),
+                ],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        assert client.chat.completions.calls[0]["messages"] == [
+            {
+                "role": "system",
+                "content": "Use <reasoning_summary> blocks as compact helper context.",
+            },
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": replay_content},
+            {"role": "user", "content": "frame 2"},
+        ]
+
+    def test_passes_request_config_kwargs_including_model(self):
+        client = _FakeChatOpenAIClient(_chat_response())
+        adapter = OpenAIChatCompletionsAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "max_completion_tokens": 99,
+                    "reasoning_effort": "high",
+                },
+            )
+        )
+
+        assert client.chat.completions.calls[0]["model"] == "gpt-5.4"
+        assert client.chat.completions.calls[0]["max_completion_tokens"] == 99
+        assert client.chat.completions.calls[0]["reasoning_effort"] == "high"
+
+    def test_returns_normalized_assistant_text(self):
+        adapter = OpenAIChatCompletionsAdapter(
+            _FakeChatOpenAIClient(_chat_response(content="RESET"))
+        )
+
+        response = adapter.invoke(_chat_request())
+
+        assert response.output_text == "RESET"
+
+    def test_returns_normalized_reasoning_text(self):
+        adapter = OpenAIChatCompletionsAdapter(
+            _FakeChatOpenAIClient(_chat_response(reasoning="inspect the top row"))
+        )
+
+        response = adapter.invoke(_chat_request())
+
+        assert response.reasoning_text == "inspect the top row"
+
+    def test_normalizes_usage(self):
+        adapter = OpenAIChatCompletionsAdapter(
+            _FakeChatOpenAIClient(
+                _chat_response(
+                    prompt_tokens=123,
+                    completion_tokens=45,
+                    total_tokens=168,
+                    reasoning_tokens=11,
+                    cached_tokens=7,
+                    cache_write_tokens=3,
+                    cost=0.75,
+                )
+            )
+        )
+
+        response = adapter.invoke(_chat_request())
+
+        assert response.usage.input_tokens == 123
+        assert response.usage.output_tokens == 45
+        assert response.usage.total_tokens == 168
+        assert response.usage.reasoning_tokens == 11
+        assert response.usage.cached_tokens == 7
+        assert response.usage.cache_write_tokens == 3
+        assert response.usage.cost == 0.75
+        assert response.usage.cost_details == {"provider_cost": 0.75}
+
+    def test_empty_choices_response_raises_empty_response_error(self):
+        adapter = OpenAIChatCompletionsAdapter(
+            _FakeChatOpenAIClient(SimpleNamespace(choices=[]))
+        )
+
+        with pytest.raises(EmptyResponseError) as exc_info:
+            adapter.invoke(_chat_request())
+
+        assert str(exc_info.value) == "API returned 200 with empty choices."
+        assert exc_info.value.response is not None
+
+
+@pytest.mark.unit
+class TestOpenAIResponsesAdapter:
+    def test_translates_system_user_assistant_conversation(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(_responses_request())
+
+        assert client.responses.calls == [
+            {
+                "model": "gpt-5.4",
+                "max_output_tokens": 128,
+                "instructions": "You are playing a game.",
+                "input": [
+                    {"role": "user", "content": "frame 1"},
+                    {"role": "assistant", "content": "MOVE_LEFT"},
+                    {"role": "user", "content": "frame 2"},
+                ],
+            }
+        ]
+
+    def test_preserves_analysis_mode_prompt_and_replay_content_in_responses_input(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+        replay_content = (
+            "<reasoning_summary>\n"
+            "inspect the top row\n"
+            "</reasoning_summary>\n\n"
+            "MOVE_LEFT"
+        )
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[
+                    Message(
+                        role="system",
+                        content=(
+                            "Use <reasoning_summary> blocks as compact helper context."
+                        ),
+                    ),
+                    Message(role="user", content="frame 1"),
+                    Message(role="assistant", content=replay_content),
+                    Message(role="user", content="frame 2"),
+                ],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        assert client.responses.calls[0]["instructions"] == (
+            "Use <reasoning_summary> blocks as compact helper context."
+        )
+        assert client.responses.calls[0]["input"] == [
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": replay_content},
+            {"role": "user", "content": "frame 2"},
+        ]
+
+    def test_passes_request_config_kwargs_including_model(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "max_output_tokens": 99,
+                    "store": False,
+                },
+            )
+        )
+
+        assert client.responses.calls[0]["model"] == "gpt-5.4"
+        assert client.responses.calls[0]["max_output_tokens"] == 99
+        assert client.responses.calls[0]["store"] is False
+
+    def test_passes_request_reasoning_config(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "reasoning": {"effort": "high"},
+                },
+            )
+        )
+
+        assert client.responses.calls[0]["reasoning"] == {"effort": "high"}
+
+    def test_extracts_assistant_text_from_responses_output(self):
+        adapter = OpenAIResponsesAdapter(
+            _FakeResponsesOpenAIClient(_responses_output(text="RESET"))
+        )
+
+        response = adapter.invoke(_responses_request())
+
+        assert response.output_text == "RESET"
+
+    def test_extracts_human_readable_reasoning_summary_if_present(self):
+        adapter = OpenAIResponsesAdapter(
+            _FakeResponsesOpenAIClient(
+                _responses_output(reasoning_summary="inspect the top row")
+            )
+        )
+
+        response = adapter.invoke(_responses_request())
+
+        assert response.reasoning_text == "inspect the top row"
+
+    def test_normalizes_usage_fields(self):
+        adapter = OpenAIResponsesAdapter(
+            _FakeResponsesOpenAIClient(
+                _responses_output(
+                    input_tokens=123,
+                    output_tokens=45,
+                    total_tokens=168,
+                    reasoning_tokens=11,
+                    cached_tokens=7,
+                    cache_write_tokens=3,
+                    cost=0.75,
+                )
+            )
+        )
+
+        response = adapter.invoke(_responses_request())
+
+        assert response.usage.input_tokens == 123
+        assert response.usage.output_tokens == 45
+        assert response.usage.total_tokens == 168
+        assert response.usage.reasoning_tokens == 11
+        assert response.usage.cached_tokens == 7
+        assert response.usage.cache_write_tokens == 3
+        assert response.usage.cost == 0.75
+        assert response.usage.cost_details == {"provider_cost": 0.75}
+
+    def test_empty_or_malformed_output_raises_empty_response_error(self):
+        adapter = OpenAIResponsesAdapter(
+            _FakeResponsesOpenAIClient(SimpleNamespace(output=[]))
+        )
+
+        with pytest.raises(EmptyResponseError) as exc_info:
+            adapter.invoke(_responses_request())
+
+        assert str(exc_info.value) == "API returned 200 with empty output."
+        assert exc_info.value.response is not None
+
+    def test_maps_first_system_message_into_instructions(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[
+                    Message(role="system", content="System prompt"),
+                    Message(role="user", content="frame"),
+                ],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        assert client.responses.calls[0]["instructions"] == "System prompt"
+
+    def test_sends_remaining_turns_in_input(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(_responses_request())
+
+        assert client.responses.calls[0]["input"] == [
+            {"role": "user", "content": "frame 1"},
+            {"role": "assistant", "content": "MOVE_LEFT"},
+            {"role": "user", "content": "frame 2"},
+        ]
+
+    def test_omits_previous_response_id_and_conversation_for_manual_rolling(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_123",
+                    "conversation": "conv_123",
+                },
+            )
+        )
+
+        assert "previous_response_id" not in client.responses.calls[0]
+        assert "conversation" not in client.responses.calls[0]
+
+
+@pytest.mark.unit
+class TestBuildModelRuntimeAdapter:
+    def test_selects_chat_completions_adapter_from_runtime_tuple(self):
+        adapter = build_model_runtime_adapter(
+            client=_FakeChatOpenAIClient(_chat_response()),
+            runtime_config={
+                "sdk": "openai-python",
+                "api": "chat_completions",
+                "state": "manual_rolling",
+            },
+            config_id="chat-config",
+        )
+
+        assert isinstance(adapter, OpenAIChatCompletionsAdapter)
+
+    def test_selects_responses_adapter_from_runtime_tuple(self):
+        adapter = build_model_runtime_adapter(
+            client=_FakeResponsesOpenAIClient(_responses_output()),
+            runtime_config={
+                "sdk": "openai-python",
+                "api": "responses",
+                "state": "manual_rolling",
+            },
+            config_id="responses-config",
+        )
+
+        assert isinstance(adapter, OpenAIResponsesAdapter)
+
+    def test_unsupported_runtime_state_fails_clearly(self):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Model config 'chat-config' uses runtime.state='previous_response_id', "
+                "but only 'manual_rolling' is supported in phase 3."
+            ),
+        ):
+            build_model_runtime_adapter(
+                client=_FakeChatOpenAIClient(_chat_response()),
+                runtime_config={
+                    "sdk": "openai-python",
+                    "api": "chat_completions",
+                    "state": "previous_response_id",
+                },
+                config_id="chat-config",
+            )

--- a/tests/unit/test_runtime_models.py
+++ b/tests/unit/test_runtime_models.py
@@ -1,0 +1,334 @@
+from types import SimpleNamespace
+
+from pydantic import ValidationError
+import pytest
+
+from benchmarking.runtime_models import (
+    Message,
+    ModelRequest,
+    ModelResponse,
+    NormalizedUsage,
+    action_metadata_from_model_response,
+    normalize_chat_completion_response,
+    normalize_responses_response,
+)
+
+
+def _normalized_model_response() -> ModelResponse:
+    return ModelResponse(
+        output_text="MOVE_LEFT",
+        reasoning_text="shift the player left",
+        usage=NormalizedUsage(
+            input_tokens=120,
+            output_tokens=30,
+            total_tokens=150,
+            reasoning_tokens=7,
+            cached_tokens=9,
+        ),
+    )
+
+
+def _chat_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="RESET",
+                    reasoning="restart the level",
+                )
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=11,
+            completion_tokens=7,
+            total_tokens=18,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=5,
+                cache_write_tokens=2,
+            ),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=3),
+            model_extra={"cost": 0.42, "cost_details": {"provider_cost": 0.42}},
+        ),
+    )
+
+
+def _responses_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                summary=[SimpleNamespace(text="restart the level")],
+                content=[],
+            ),
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                content=[SimpleNamespace(type="output_text", text="RESET")],
+            ),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=5,
+                cache_write_tokens=2,
+            ),
+            output_tokens_details=SimpleNamespace(reasoning_tokens=3),
+            model_extra={"cost": 0.42, "cost_details": {"provider_cost": 0.42}},
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestRuntimeModels:
+    def test_model_request_validates_required_fields(self):
+        with pytest.raises(ValidationError):
+            ModelRequest(messages=[Message(role="user", content="frame")])
+
+    def test_model_response_validates_required_fields(self):
+        with pytest.raises(ValidationError):
+            ModelResponse(output_text="MOVE_LEFT")
+
+    def test_normalized_usage_defaults_to_zeros(self):
+        usage = NormalizedUsage()
+
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+        assert usage.reasoning_tokens == 0
+        assert usage.cached_tokens == 0
+        assert usage.cache_write_tokens == 0
+        assert usage.cost == 0.0
+        assert usage.cost_details == {}
+
+    def test_normalized_usage_supports_reasoning_and_cache_details(self):
+        usage = NormalizedUsage(
+            input_tokens=200,
+            output_tokens=40,
+            total_tokens=240,
+            reasoning_tokens=10,
+            cached_tokens=25,
+            cache_write_tokens=5,
+            cost=1.25,
+            cost_details={"provider_cost": 1.25},
+        )
+
+        assert usage.reasoning_tokens == 10
+        assert usage.cached_tokens == 25
+        assert usage.cache_write_tokens == 5
+        assert usage.cost == 1.25
+        assert usage.cost_details == {"provider_cost": 1.25}
+
+    def test_model_response_allows_empty_output_text(self):
+        response = ModelResponse(output_text="", usage=NormalizedUsage())
+
+        assert response.output_text == ""
+        assert response.usage.total_tokens == 0
+
+    def test_action_metadata_projection_maps_output_reasoning_usage_and_cost(self):
+        metadata = action_metadata_from_model_response(
+            _normalized_model_response(),
+            pricing={"input": 2.50, "output": 15.00},
+        )
+
+        assert metadata.output == "MOVE_LEFT"
+        assert metadata.reasoning == "shift the player left"
+        assert metadata.usage.input_tokens == 120
+        assert metadata.usage.output_tokens == 30
+        assert metadata.usage.total_tokens == 150
+        assert metadata.usage.input_tokens_details.cached_tokens == 9
+        assert metadata.usage.output_tokens_details.reasoning_tokens == 7
+        assert metadata.cost.input_cost == pytest.approx(0.0003)
+        assert metadata.cost.output_cost == pytest.approx(0.00045)
+        assert metadata.cost.total_cost == pytest.approx(0.00075)
+
+    def test_chat_response_normalizer_uses_first_choice_message_content(self):
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="FIRST",
+                        reasoning="first-reasoning",
+                    )
+                ),
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="SECOND",
+                        reasoning="second-reasoning",
+                    )
+                ),
+            ]
+        )
+
+        model_response = normalize_chat_completion_response(response)
+
+        assert model_response.output_text == "FIRST"
+        assert model_response.reasoning_text == "first-reasoning"
+
+    def test_chat_and_responses_metadata_projection_have_same_schema(self):
+        chat_metadata = action_metadata_from_model_response(
+            normalize_chat_completion_response(_chat_response()),
+            pricing={"input": 2.50, "output": 15.00},
+        )
+        responses_metadata = action_metadata_from_model_response(
+            normalize_responses_response(_responses_response()),
+            pricing={"input": 2.50, "output": 15.00},
+        )
+
+        assert chat_metadata.model_dump() == responses_metadata.model_dump()
+
+    def test_chat_usage_total_matches_input_plus_output_tokens(self):
+        model_response = normalize_chat_completion_response(_chat_response())
+
+        assert model_response.usage.total_tokens == (
+            model_response.usage.input_tokens + model_response.usage.output_tokens
+        )
+        assert model_response.usage.total_tokens == 18
+
+    def test_responses_usage_total_matches_input_plus_output_tokens(self):
+        model_response = normalize_responses_response(_responses_response())
+
+        assert model_response.usage.total_tokens == (
+            model_response.usage.input_tokens + model_response.usage.output_tokens
+        )
+        assert model_response.usage.total_tokens == 18
+
+    def test_responses_metadata_projection_maps_reasoning_usage_and_cost(self):
+        raw_response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[SimpleNamespace(text="inspect the board")],
+                    content=[],
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="PUSH")],
+                ),
+            ],
+            usage=SimpleNamespace(
+                input_tokens=1_000,
+                output_tokens=200,
+                total_tokens=1_200,
+                input_tokens_details=SimpleNamespace(cached_tokens=50),
+                output_tokens_details=SimpleNamespace(reasoning_tokens=25),
+            ),
+        )
+
+        metadata = action_metadata_from_model_response(
+            normalize_responses_response(raw_response),
+            pricing={"input": 2.50, "output": 15.00},
+        )
+
+        assert metadata.output == "PUSH"
+        assert metadata.reasoning == "inspect the board"
+        assert metadata.usage.input_tokens == 1_000
+        assert metadata.usage.output_tokens == 200
+        assert metadata.usage.total_tokens == 1_200
+        assert metadata.usage.input_tokens_details.cached_tokens == 50
+        assert metadata.usage.output_tokens_details.reasoning_tokens == 25
+        assert metadata.cost.input_cost == pytest.approx(0.0025)
+        assert metadata.cost.output_cost == pytest.approx(0.003)
+        assert metadata.cost.total_cost == pytest.approx(0.0055)
+
+    def test_responses_normalizer_extracts_reasoning_summary_text_items(self):
+        raw_response = {
+            "output": [
+                {
+                    "id": "rs_123",
+                    "type": "reasoning",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": "**Answering a simple question**\n\nParis is the capital.",
+                        }
+                    ],
+                },
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "The capital of France is Paris.",
+                        }
+                    ],
+                },
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            },
+        }
+
+        model_response = normalize_responses_response(raw_response)
+
+        assert model_response.output_text == "The capital of France is Paris."
+        assert model_response.reasoning_text == (
+            "**Answering a simple question**\n\nParis is the capital."
+        )
+
+    def test_responses_normalizer_maps_dict_usage_schema_and_cost_without_double_counting_reasoning_tokens(
+        self,
+    ):
+        raw_response = {
+            "id": "resp_67ccd2bed1ec8190b14f964abc0542670bb6a6b452d3795b",
+            "object": "response",
+            "created_at": 1741476542,
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_67ccd2bf17f0819081ff3bb2cf6508e60bb6a6b452d3795b",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "RESET",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "reasoning": {
+                "effort": None,
+                "summary": None,
+            },
+            "usage": {
+                "input_tokens": 36,
+                "input_tokens_details": {
+                    "cached_tokens": 0,
+                },
+                "output_tokens": 87,
+                "output_tokens_details": {
+                    "reasoning_tokens": 10,
+                },
+                "total_tokens": 123,
+            },
+        }
+
+        model_response = normalize_responses_response(raw_response)
+        metadata = action_metadata_from_model_response(
+            model_response=model_response,
+            pricing={"input": 2.50, "output": 15.00},
+        )
+
+        assert model_response.output_text == "RESET"
+        assert model_response.usage.input_tokens == 36
+        assert model_response.usage.cached_tokens == 0
+        assert model_response.usage.output_tokens == 87
+        assert model_response.usage.reasoning_tokens == 10
+        assert model_response.usage.total_tokens == 123
+        assert model_response.usage.total_tokens == (
+            model_response.usage.input_tokens + model_response.usage.output_tokens
+        )
+        assert metadata.usage.output_tokens_details.reasoning_tokens == 10
+        assert metadata.cost.input_cost == pytest.approx(0.00009)
+        assert metadata.cost.output_cost == pytest.approx(0.001305)
+        assert metadata.cost.total_cost == pytest.approx(0.001395)

--- a/tests/unit/test_swarm.py
+++ b/tests/unit/test_swarm.py
@@ -32,7 +32,8 @@ class DummyAgent:
 
 
 class FakeArcade:
-    def __init__(self) -> None:
+    def __init__(self, operation_mode=None) -> None:  # noqa: ANN001
+        self.requested_operation_mode = operation_mode
         self.operation_mode = SimpleNamespace(ONLINE="online").ONLINE
         self.opened_tags: list[str] | None = None
         self.closed_card_id: str | None = None


### PR DESCRIPTION
## Summary
- Introduce a runtime adapter abstraction that decouples the agent from specific OpenAI SDK call patterns, enabling support for both Chat Completions and Responses APIs through a unified interface
- Add opt-in analysis mode that replays prior reasoning summaries inline in assistant turns, letting the model see its earlier thought process on subsequent turns
- Fix double-reset bug where `BenchmarkingAgent.do_action_request` never set `_previous_action`, leaving the reset guard inert

## Test plan
- [x] 124 unit tests passing across all modules
- [x] Manual end-to-end verification with all three config routes:
  - `--config openai-gpt-5-4-2026-03-05` (Chat Completions)
  - `--config openai-gpt-5-4-2026-03-05-responses` (Responses API)
  - `--config openai-gpt-5-4-2026-03-05-responses-analysis` (Responses API + analysis mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)