### PR TITLE
Add Google Gemini adapter

### DIFF
--- a/benchmarking/model_config.py
+++ b/benchmarking/model_config.py
@@ -8,6 +8,7 @@ REQUIRED_CONFIG_SECTIONS = ("runtime", "client", "request")
 SUPPORTED_RUNTIME_PAIRS = frozenset(
     {
         ("anthropic-python", "messages"),
+        ("google-genai", "generate_content"),
         ("openai-python", "chat_completions"),
         ("openai-python", "responses"),
     }

--- a/benchmarking/runtime_adapters.py
+++ b/benchmarking/runtime_adapters.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from google.genai import types as google_genai_types
+
 from .runtime_models import (
     ModelRequest,
     ModelResponse,
     normalize_anthropic_messages_response,
     normalize_chat_completion_response,
+    normalize_google_genai_response,
     normalize_responses_response,
 )
 
@@ -162,6 +165,61 @@ class AnthropicMessagesAdapter:
         return normalize_anthropic_messages_response(raw_response)
 
 
+class GoogleGenAIGenerateContentAdapter:
+    """Adapter for the native Google `google-genai` SDK.
+
+    Translates our common ``Message`` schema into Gemini's ``Contents`` shape:
+    a leading ``system`` message becomes ``GenerateContentConfig.system_instruction``,
+    ``assistant`` is renamed to ``model``, and everything else flows through as
+    text ``Part``s on the matching role.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @staticmethod
+    def _build_call_kwargs(request: ModelRequest) -> dict[str, Any]:
+        request_config = dict(request.request_config)
+        model = request_config.pop("model", None)
+        if not model:
+            raise ValueError(
+                "Google GenAI request_config is missing required 'model'."
+            )
+
+        system_instruction: str | None = None
+        messages = list(request.messages)
+        if messages and messages[0].role == "system":
+            system_instruction = messages[0].content
+            messages = messages[1:]
+
+        contents: list[google_genai_types.Content] = []
+        for message in messages:
+            role = "model" if message.role == "assistant" else message.role
+            contents.append(
+                google_genai_types.Content(
+                    role=role,
+                    parts=[google_genai_types.Part(text=message.content)],
+                )
+            )
+
+        config_kwargs: dict[str, Any] = dict(request_config)
+        if system_instruction is not None:
+            config_kwargs.setdefault("system_instruction", system_instruction)
+
+        config = google_genai_types.GenerateContentConfig(**config_kwargs)
+        return {
+            "model": model,
+            "contents": contents,
+            "config": config,
+        }
+
+    def invoke(self, request: ModelRequest) -> ModelResponse:
+        raw_response = self._client.models.generate_content(
+            **self._build_call_kwargs(request),
+        )
+        return normalize_google_genai_response(raw_response)
+
+
 def build_model_runtime_adapter(
     *,
     client: Any,
@@ -182,6 +240,8 @@ def build_model_runtime_adapter(
         return OpenAIResponsesAdapter(client)
     if runtime_key == ("anthropic-python", "messages"):
         return AnthropicMessagesAdapter(client)
+    if runtime_key == ("google-genai", "generate_content"):
+        return GoogleGenAIGenerateContentAdapter(client)
 
     raise ValueError(
         f"Model config '{config_id}' uses unsupported runtime "

--- a/benchmarking/runtime_clients.py
+++ b/benchmarking/runtime_clients.py
@@ -4,11 +4,13 @@ import os
 from typing import Any
 
 from anthropic import Anthropic as AnthropicClient
+from google import genai as google_genai
 from openai import OpenAI as OpenAIClient
 
 DEFAULT_ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 DEFAULT_OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_OPENAI_API_KEY_ENV = "OPENROUTER_API_KEY"
+DEFAULT_GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY"
 
 
 def _read_required_api_key(
@@ -60,6 +62,14 @@ def build_model_runtime_client(
             default_api_key_env=DEFAULT_ANTHROPIC_API_KEY_ENV,
         )
         return AnthropicClient(api_key=api_key)
+
+    if sdk == "google-genai":
+        api_key = _read_required_api_key(
+            client_config=client_config,
+            config_id=config_id,
+            default_api_key_env=DEFAULT_GOOGLE_API_KEY_ENV,
+        )
+        return google_genai.Client(api_key=api_key)
 
     raise ValueError(
         f"Model config '{config_id}' uses unsupported runtime "

--- a/benchmarking/runtime_models.py
+++ b/benchmarking/runtime_models.py
@@ -139,6 +139,46 @@ def _normalize_responses_usage(usage: Any) -> dict[str, Any]:
     return normalized_usage_kwargs
 
 
+def _normalize_google_genai_usage(usage: Any) -> dict[str, Any]:
+    """Normalize Gemini `usage_metadata` into our common token-accounting shape.
+
+    Gemini reports tokens with these fields (any of which may be missing or
+    ``None`` when the value is zero):
+
+    - ``prompt_token_count``: input tokens, INCLUDING any cached prompt tokens.
+    - ``candidates_token_count``: visible output tokens (assistant text).
+    - ``thoughts_token_count``: hidden reasoning tokens. Gemini bills these at
+      the *output* rate.
+    - ``cached_content_token_count``: subset of the prompt served from cache.
+    - ``total_token_count``: prompt + candidates + thoughts (+ tool tokens).
+
+    To keep cost math consistent with the other adapters (where
+    ``output_cost = output_tokens * output_price`` already covers reasoning),
+    we fold ``thoughts_token_count`` into ``output_tokens`` and keep it
+    separately under ``reasoning_tokens`` for reporting.
+    """
+    if not usage:
+        return {}
+
+    prompt_tokens = _value_from_response_object(usage, "prompt_token_count", 0) or 0
+    candidates_tokens = (
+        _value_from_response_object(usage, "candidates_token_count", 0) or 0
+    )
+    thoughts_tokens = (
+        _value_from_response_object(usage, "thoughts_token_count", 0) or 0
+    )
+    cached_tokens = (
+        _value_from_response_object(usage, "cached_content_token_count", 0) or 0
+    )
+    return {
+        "input_tokens": prompt_tokens,
+        "output_tokens": candidates_tokens + thoughts_tokens,
+        "total_tokens": prompt_tokens + candidates_tokens + thoughts_tokens,
+        "reasoning_tokens": thoughts_tokens,
+        "cached_tokens": cached_tokens,
+    }
+
+
 def _normalize_anthropic_messages_usage(usage: Any) -> dict[str, Any]:
     if not usage:
         return {}
@@ -216,6 +256,55 @@ def _extract_anthropic_messages_output_text(response: Any) -> str:
     return "".join(text_parts)
 
 
+def _google_genai_part_text(part: Any) -> str:
+    text = _value_from_response_object(part, "text")
+    if not text:
+        return ""
+    return text
+
+
+def _google_genai_message_parts(response: Any) -> list[Any]:
+    candidates = _value_from_response_object(response, "candidates", []) or []
+    if not candidates:
+        return []
+
+    content = _value_from_response_object(candidates[0], "content")
+    if content is None:
+        return []
+
+    return _value_from_response_object(content, "parts", []) or []
+
+
+def _extract_google_genai_output_text(response: Any) -> str:
+    text_parts: list[str] = []
+    for part in _google_genai_message_parts(response):
+        if _value_from_response_object(part, "thought", False):
+            continue
+        text_parts.append(_google_genai_part_text(part))
+
+    output_text = "".join(text_parts)
+    if not output_text:
+        raise EmptyResponseError(
+            "API returned 200 with empty output.",
+            response=response,
+        )
+    return output_text
+
+
+def _extract_google_genai_reasoning_text(response: Any) -> str | None:
+    reasoning_parts: list[str] = []
+    for part in _google_genai_message_parts(response):
+        if not _value_from_response_object(part, "thought", False):
+            continue
+        text = _google_genai_part_text(part)
+        if text:
+            reasoning_parts.append(text)
+
+    if not reasoning_parts:
+        return None
+    return "\n".join(reasoning_parts)
+
+
 def _extract_reasoning_text_fragment(item: Any) -> str | None:
     if isinstance(item, str):
         return item
@@ -274,6 +363,19 @@ def normalize_responses_response(response: Any) -> ModelResponse:
         usage=NormalizedUsage(
             **_normalize_responses_usage(
                 _value_from_response_object(response, "usage"),
+            )
+        ),
+        raw_response=response,
+    )
+
+
+def normalize_google_genai_response(response: Any) -> ModelResponse:
+    return ModelResponse(
+        output_text=_extract_google_genai_output_text(response),
+        reasoning_text=_extract_google_genai_reasoning_text(response),
+        usage=NormalizedUsage(
+            **_normalize_google_genai_usage(
+                _value_from_response_object(response, "usage_metadata"),
             )
         ),
         raw_response=response,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "anthropic==0.95.0",
     "arc-agi>=0.9.8",
     "dotenv>=0.9.9",
+    "google-genai>=2.4.0",
     "langchain[openai]>=0.3.27",
     "langgraph>=0.6.3",
     "langgraph-checkpoint-sqlite>=2.0.11",

--- a/tests/unit/test_runtime_adapters.py
+++ b/tests/unit/test_runtime_adapters.py
@@ -6,6 +6,7 @@ from benchmarking.exceptions import EmptyResponseError
 from benchmarking.model_config import get_model_config
 from benchmarking.runtime_adapters import (
     AnthropicMessagesAdapter,
+    GoogleGenAIGenerateContentAdapter,
     OpenAIChatCompletionsAdapter,
     OpenAIResponsesAdapter,
     build_model_runtime_adapter,
@@ -913,6 +914,213 @@ class TestAnthropicMessagesAdapter:
         assert request_kwargs is not request.request_config
 
 
+class _FakeGoogleGenAIModels:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    def generate_content(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+class _FakeGoogleGenAIClient:
+    def __init__(self, response: object) -> None:
+        self.models = _FakeGoogleGenAIModels(response)
+
+
+def _google_genai_response(
+    *,
+    text: str = "MOVE_LEFT",
+    reasoning: str | None = None,
+    prompt_token_count: int = 11,
+    candidates_token_count: int = 7,
+    thoughts_token_count: int = 0,
+    cached_content_token_count: int = 0,
+) -> SimpleNamespace:
+    parts: list[SimpleNamespace] = []
+    if reasoning is not None:
+        parts.append(SimpleNamespace(text=reasoning, thought=True))
+    parts.append(SimpleNamespace(text=text, thought=False))
+
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(content=SimpleNamespace(role="model", parts=parts))
+        ],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_token_count,
+            candidates_token_count=candidates_token_count,
+            thoughts_token_count=thoughts_token_count,
+            cached_content_token_count=cached_content_token_count,
+            total_token_count=(
+                prompt_token_count + candidates_token_count + thoughts_token_count
+            ),
+        ),
+    )
+
+
+def _google_genai_request() -> ModelRequest:
+    return ModelRequest(
+        messages=[
+            Message(role="system", content="You are playing a game."),
+            Message(role="user", content="frame 1"),
+            Message(role="assistant", content="MOVE_LEFT"),
+            Message(role="user", content="frame 2"),
+        ],
+        request_config={
+            "model": "models/gemini-test",
+            "max_output_tokens": 128,
+            "thinking_config": {"thinking_level": "minimal"},
+        },
+    )
+
+
+@pytest.mark.unit
+class TestGoogleGenAIGenerateContentAdapter:
+    def test_calls_models_generate_content_with_model_contents_and_config(self):
+        client = _FakeGoogleGenAIClient(_google_genai_response())
+        adapter = GoogleGenAIGenerateContentAdapter(client)
+
+        adapter.invoke(_google_genai_request())
+
+        assert len(client.models.calls) == 1
+        call = client.models.calls[0]
+        assert set(call.keys()) == {"model", "contents", "config"}
+        assert call["model"] == "models/gemini-test"
+
+    def test_maps_leading_system_message_to_config_system_instruction(self):
+        call_kwargs = GoogleGenAIGenerateContentAdapter._build_call_kwargs(
+            _google_genai_request()
+        )
+
+        assert call_kwargs["config"].system_instruction == "You are playing a game."
+
+    def test_translates_remaining_messages_into_user_and_model_contents(self):
+        call_kwargs = GoogleGenAIGenerateContentAdapter._build_call_kwargs(
+            _google_genai_request()
+        )
+
+        contents = call_kwargs["contents"]
+        assert [content.role for content in contents] == ["user", "model", "user"]
+        assert [content.parts[0].text for content in contents] == [
+            "frame 1",
+            "MOVE_LEFT",
+            "frame 2",
+        ]
+
+    def test_keeps_user_only_conversation_without_system_instruction(self):
+        call_kwargs = GoogleGenAIGenerateContentAdapter._build_call_kwargs(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "models/gemini-test",
+                    "max_output_tokens": 64,
+                },
+            )
+        )
+
+        assert call_kwargs["config"].system_instruction is None
+        assert [content.role for content in call_kwargs["contents"]] == ["user"]
+
+    def test_forwards_thinking_config_into_generate_content_config(self):
+        call_kwargs = GoogleGenAIGenerateContentAdapter._build_call_kwargs(
+            _google_genai_request()
+        )
+
+        thinking_config = call_kwargs["config"].thinking_config
+        assert thinking_config is not None
+        assert thinking_config.thinking_level.value == "MINIMAL"
+
+    def test_forwards_max_output_tokens_into_generate_content_config(self):
+        call_kwargs = GoogleGenAIGenerateContentAdapter._build_call_kwargs(
+            _google_genai_request()
+        )
+
+        assert call_kwargs["config"].max_output_tokens == 128
+
+    def test_does_not_mutate_original_request_config(self):
+        request_config = {
+            "model": "models/gemini-test",
+            "max_output_tokens": 64,
+            "thinking_config": {"thinking_level": "minimal"},
+        }
+        request = ModelRequest(
+            messages=[
+                Message(role="system", content="System prompt"),
+                Message(role="user", content="frame"),
+            ],
+            request_config=request_config,
+        )
+
+        GoogleGenAIGenerateContentAdapter._build_call_kwargs(request)
+
+        assert request.request_config == {
+            "model": "models/gemini-test",
+            "max_output_tokens": 64,
+            "thinking_config": {"thinking_level": "minimal"},
+        }
+
+    def test_raises_when_model_missing_from_request_config(self):
+        request = ModelRequest(
+            messages=[Message(role="user", content="frame")],
+            request_config={"max_output_tokens": 64},
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Google GenAI request_config is missing required 'model'.",
+        ):
+            GoogleGenAIGenerateContentAdapter._build_call_kwargs(request)
+
+    def test_normalizes_response_output_text_reasoning_and_usage(self):
+        client = _FakeGoogleGenAIClient(
+            _google_genai_response(
+                text="RESET",
+                reasoning="thinking",
+                prompt_token_count=100,
+                candidates_token_count=20,
+                thoughts_token_count=50,
+            )
+        )
+        adapter = GoogleGenAIGenerateContentAdapter(client)
+
+        response = adapter.invoke(_google_genai_request())
+
+        assert response.output_text == "RESET"
+        assert response.reasoning_text == "thinking"
+        assert response.usage.input_tokens == 100
+        assert response.usage.output_tokens == 70
+        assert response.usage.reasoning_tokens == 50
+        assert response.usage.total_tokens == 170
+
+    def test_raises_empty_response_error_when_only_thought_parts_returned(self):
+        client = _FakeGoogleGenAIClient(
+            SimpleNamespace(
+                candidates=[
+                    SimpleNamespace(
+                        content=SimpleNamespace(
+                            role="model",
+                            parts=[SimpleNamespace(text="thinking", thought=True)],
+                        )
+                    )
+                ],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=10,
+                    candidates_token_count=0,
+                    thoughts_token_count=5,
+                    cached_content_token_count=0,
+                    total_token_count=15,
+                ),
+            )
+        )
+        adapter = GoogleGenAIGenerateContentAdapter(client)
+
+        with pytest.raises(EmptyResponseError) as exc_info:
+            adapter.invoke(_google_genai_request())
+
+        assert str(exc_info.value) == "API returned 200 with empty output."
+
+
 @pytest.mark.unit
 class TestBuildModelRuntimeAdapter:
     def test_selects_chat_completions_adapter_from_runtime_tuple(self):
@@ -953,6 +1161,19 @@ class TestBuildModelRuntimeAdapter:
         )
 
         assert isinstance(adapter, AnthropicMessagesAdapter)
+
+    def test_selects_google_genai_adapter_from_runtime_tuple(self):
+        adapter = build_model_runtime_adapter(
+            client=_FakeGoogleGenAIClient(_google_genai_response()),
+            runtime_config={
+                "sdk": "google-genai",
+                "api": "generate_content",
+                "state": "manual_rolling",
+            },
+            config_id="google-config",
+        )
+
+        assert isinstance(adapter, GoogleGenAIGenerateContentAdapter)
 
     def test_checked_in_openai_configs_select_existing_openai_adapters(self):
         chat_config = get_model_config("openai-gpt-5-4-2026-03-05")

--- a/tests/unit/test_runtime_clients.py
+++ b/tests/unit/test_runtime_clients.py
@@ -13,6 +13,16 @@ class _FakeAnthropicClient:
         self.kwargs = kwargs
 
 
+class _FakeGoogleGenAIClient:
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+
+
+class _FakeGoogleGenAIModule:
+    def __init__(self) -> None:
+        self.Client = _FakeGoogleGenAIClient
+
+
 @pytest.mark.unit
 class TestBuildModelRuntimeClient:
     def test_builds_openai_client_from_runtime_sdk(self, monkeypatch):
@@ -137,7 +147,42 @@ class TestBuildModelRuntimeClient:
             "the ANTHROPIC_API_KEY environment variable to be set in your .env file."
         )
 
-    def test_unsupported_runtime_sdk_raises_clear_error(self):
+    def test_builds_google_genai_client_from_runtime_sdk(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setattr(
+            runtime_clients,
+            "google_genai",
+            _FakeGoogleGenAIModule(),
+        )
+
+        client = runtime_clients.build_model_runtime_client(
+            runtime_config={"sdk": "google-genai"},
+            client_config={"api_key_env": "GOOGLE_API_KEY"},
+            config_id="google-config",
+        )
+
+        assert isinstance(client, _FakeGoogleGenAIClient)
+        assert client.kwargs == {"api_key": "test-google-key"}
+
+    def test_google_genai_client_uses_default_google_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setattr(
+            runtime_clients,
+            "google_genai",
+            _FakeGoogleGenAIModule(),
+        )
+
+        client = runtime_clients.build_model_runtime_client(
+            runtime_config={"sdk": "google-genai"},
+            client_config={},
+            config_id="google-config",
+        )
+
+        assert client.kwargs == {"api_key": "test-google-key"}
+
+    def test_missing_google_api_key_raises_config_specific_error(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
         with pytest.raises(ValueError) as exc_info:
             runtime_clients.build_model_runtime_client(
                 runtime_config={"sdk": "google-genai"},
@@ -146,6 +191,20 @@ class TestBuildModelRuntimeClient:
             )
 
         assert str(exc_info.value) == (
-            "Model config 'google-config' uses unsupported runtime "
-            "(sdk='google-genai')."
+            "No GOOGLE_API_KEY set. "
+            "The selected model config 'google-config' requires "
+            "the GOOGLE_API_KEY environment variable to be set in your .env file."
+        )
+
+    def test_unsupported_runtime_sdk_raises_clear_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            runtime_clients.build_model_runtime_client(
+                runtime_config={"sdk": "made-up-sdk"},
+                client_config={"api_key_env": "MADE_UP_API_KEY"},
+                config_id="made-up-config",
+            )
+
+        assert str(exc_info.value) == (
+            "Model config 'made-up-config' uses unsupported runtime "
+            "(sdk='made-up-sdk')."
         )

--- a/tests/unit/test_runtime_models.py
+++ b/tests/unit/test_runtime_models.py
@@ -12,6 +12,7 @@ from benchmarking.runtime_models import (
     action_metadata_from_model_response,
     normalize_anthropic_messages_response,
     normalize_chat_completion_response,
+    normalize_google_genai_response,
     normalize_responses_response,
 )
 
@@ -78,6 +79,45 @@ def _responses_response() -> SimpleNamespace:
             ),
             output_tokens_details=SimpleNamespace(reasoning_tokens=3),
             model_extra={"cost": 0.42, "cost_details": {"provider_cost": 0.42}},
+        ),
+    )
+
+
+def _google_genai_part(
+    *,
+    text: str = "",
+    thought: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(text=text, thought=thought)
+
+
+def _google_genai_response(
+    *,
+    parts: list[SimpleNamespace] | None = None,
+    prompt_token_count: int = 11,
+    candidates_token_count: int = 7,
+    thoughts_token_count: int = 0,
+    cached_content_token_count: int = 0,
+    total_token_count: int | None = None,
+) -> SimpleNamespace:
+    if parts is None:
+        parts = [_google_genai_part(text="MOVE_LEFT")]
+    if total_token_count is None:
+        total_token_count = (
+            prompt_token_count + candidates_token_count + thoughts_token_count
+        )
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(role="model", parts=parts),
+            )
+        ],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_token_count,
+            candidates_token_count=candidates_token_count,
+            thoughts_token_count=thoughts_token_count,
+            cached_content_token_count=cached_content_token_count,
+            total_token_count=total_token_count,
         ),
     )
 
@@ -465,6 +505,276 @@ class TestRuntimeModels:
         model_response = normalize_anthropic_messages_response(raw_response)
 
         assert model_response.raw_response is raw_response
+
+    def test_google_genai_normalizer_extracts_text_from_visible_parts(self):
+        response = _google_genai_response(
+            parts=[
+                _google_genai_part(text="MOVE", thought=False),
+                _google_genai_part(text="_LEFT", thought=False),
+            ]
+        )
+
+        model_response = normalize_google_genai_response(response)
+
+        assert model_response.output_text == "MOVE_LEFT"
+
+    def test_google_genai_normalizer_skips_thought_parts_in_output_text(self):
+        response = _google_genai_response(
+            parts=[
+                _google_genai_part(text="inspect the board", thought=True),
+                _google_genai_part(text="RESET", thought=False),
+            ]
+        )
+
+        model_response = normalize_google_genai_response(response)
+
+        assert model_response.output_text == "RESET"
+        assert model_response.reasoning_text == "inspect the board"
+
+    def test_google_genai_normalizer_concatenates_multiple_thought_parts(self):
+        response = _google_genai_response(
+            parts=[
+                _google_genai_part(text="first thought", thought=True),
+                _google_genai_part(text="second thought", thought=True),
+                _google_genai_part(text="ANSWER", thought=False),
+            ]
+        )
+
+        model_response = normalize_google_genai_response(response)
+
+        assert model_response.output_text == "ANSWER"
+        assert model_response.reasoning_text == "first thought\nsecond thought"
+
+    def test_google_genai_normalizer_returns_none_reasoning_when_no_thought_parts(self):
+        response = _google_genai_response(
+            parts=[_google_genai_part(text="MOVE_LEFT", thought=False)]
+        )
+
+        model_response = normalize_google_genai_response(response)
+
+        assert model_response.reasoning_text is None
+
+    def test_google_genai_normalizer_raises_when_no_visible_text_parts(self):
+        response = _google_genai_response(
+            parts=[_google_genai_part(text="hidden thought", thought=True)]
+        )
+
+        with pytest.raises(EmptyResponseError) as exc_info:
+            normalize_google_genai_response(response)
+
+        assert str(exc_info.value) == "API returned 200 with empty output."
+        assert exc_info.value.response is response
+
+    def test_google_genai_normalizer_raises_when_no_candidates(self):
+        response = SimpleNamespace(
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=5,
+                candidates_token_count=0,
+                thoughts_token_count=0,
+                cached_content_token_count=0,
+                total_token_count=5,
+            ),
+        )
+
+        with pytest.raises(EmptyResponseError):
+            normalize_google_genai_response(response)
+
+    def test_google_genai_normalizer_maps_prompt_to_input_tokens(self):
+        model_response = normalize_google_genai_response(
+            _google_genai_response(
+                prompt_token_count=120,
+                candidates_token_count=30,
+                thoughts_token_count=0,
+            )
+        )
+
+        assert model_response.usage.input_tokens == 120
+
+    def test_google_genai_normalizer_folds_thoughts_into_output_tokens(self):
+        """Critical for cost: Gemini bills (candidates + thoughts) at the output
+        rate, so output_tokens must include thoughts so that
+        output_cost = output_tokens * output_price matches Gemini billing.
+        """
+        model_response = normalize_google_genai_response(
+            _google_genai_response(
+                prompt_token_count=100,
+                candidates_token_count=30,
+                thoughts_token_count=200,
+            )
+        )
+
+        assert model_response.usage.output_tokens == 230
+        assert model_response.usage.reasoning_tokens == 200
+
+    def test_google_genai_normalizer_total_tokens_equals_prompt_plus_output_tokens(
+        self,
+    ):
+        model_response = normalize_google_genai_response(
+            _google_genai_response(
+                prompt_token_count=100,
+                candidates_token_count=30,
+                thoughts_token_count=200,
+            )
+        )
+
+        assert model_response.usage.total_tokens == (
+            model_response.usage.input_tokens + model_response.usage.output_tokens
+        )
+        assert model_response.usage.total_tokens == 330
+
+    def test_google_genai_normalizer_maps_cached_content_to_cached_tokens(self):
+        model_response = normalize_google_genai_response(
+            _google_genai_response(
+                prompt_token_count=500,
+                candidates_token_count=20,
+                cached_content_token_count=400,
+            )
+        )
+
+        assert model_response.usage.cached_tokens == 400
+        assert model_response.usage.cache_write_tokens == 0
+
+    def test_google_genai_normalizer_treats_missing_usage_fields_as_zero(self):
+        response = SimpleNamespace(
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(
+                        role="model",
+                        parts=[_google_genai_part(text="HI")],
+                    )
+                )
+            ],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=None,
+                candidates_token_count=None,
+                thoughts_token_count=None,
+                cached_content_token_count=None,
+                total_token_count=None,
+            ),
+        )
+
+        model_response = normalize_google_genai_response(response)
+
+        assert model_response.usage.input_tokens == 0
+        assert model_response.usage.output_tokens == 0
+        assert model_response.usage.total_tokens == 0
+        assert model_response.usage.reasoning_tokens == 0
+        assert model_response.usage.cached_tokens == 0
+
+    def test_google_genai_normalizer_maps_dict_response_and_usage_schema(self):
+        raw_response = {
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [
+                            {"text": "thinking through", "thought": True},
+                            {"text": "TOKEN_PROBE", "thought": False},
+                        ],
+                    }
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 50,
+                "candidates_token_count": 7,
+                "thoughts_token_count": 13,
+                "cached_content_token_count": 5,
+                "total_token_count": 70,
+            },
+        }
+
+        model_response = normalize_google_genai_response(raw_response)
+
+        assert model_response.output_text == "TOKEN_PROBE"
+        assert model_response.reasoning_text == "thinking through"
+        assert model_response.usage.input_tokens == 50
+        assert model_response.usage.output_tokens == 20
+        assert model_response.usage.reasoning_tokens == 13
+        assert model_response.usage.cached_tokens == 5
+        assert model_response.usage.total_tokens == 70
+
+    def test_google_genai_raw_response_is_preserved(self):
+        raw_response = _google_genai_response()
+
+        model_response = normalize_google_genai_response(raw_response)
+
+        assert model_response.raw_response is raw_response
+
+    def test_google_genai_metadata_projection_costs_match_gemini_billing(self):
+        """End-to-end check: with `input=$2/M` and `output=$10/M`, a response
+        with 1,000 prompt / 200 candidate / 300 thought tokens must price out
+        as ``1_000*2e-6 + (200+300)*10e-6 = $0.007``.
+        """
+        raw_response = _google_genai_response(
+            parts=[_google_genai_part(text="PUSH")],
+            prompt_token_count=1_000,
+            candidates_token_count=200,
+            thoughts_token_count=300,
+        )
+
+        metadata = action_metadata_from_model_response(
+            normalize_google_genai_response(raw_response),
+            pricing={"input": 2.00, "output": 10.00},
+        )
+
+        assert metadata.output == "PUSH"
+        assert metadata.usage.input_tokens == 1_000
+        assert metadata.usage.output_tokens == 500
+        assert metadata.usage.total_tokens == 1_500
+        assert metadata.usage.output_tokens_details.reasoning_tokens == 300
+        assert metadata.cost.input_cost == pytest.approx(0.002)
+        assert metadata.cost.output_cost == pytest.approx(0.005)
+        assert metadata.cost.total_cost == pytest.approx(0.007)
+
+    def test_google_genai_reasoning_tokens_billed_at_output_price(self):
+        """Cost regression: thinking tokens with no visible output must still
+        be billed at the output rate, otherwise we under-report Gemini cost."""
+        raw_response = _google_genai_response(
+            parts=[_google_genai_part(text="X")],
+            prompt_token_count=0,
+            candidates_token_count=0,
+            thoughts_token_count=1_000_000,
+        )
+
+        metadata = action_metadata_from_model_response(
+            normalize_google_genai_response(raw_response),
+            pricing={"input": 2.00, "output": 9.00},
+        )
+
+        assert metadata.usage.output_tokens == 1_000_000
+        assert metadata.cost.output_cost == pytest.approx(9.00)
+        assert metadata.cost.total_cost == pytest.approx(9.00)
+
+    def test_google_genai_metadata_projection_matches_anthropic_metadata_schema(
+        self,
+    ):
+        gemini_metadata = action_metadata_from_model_response(
+            normalize_google_genai_response(
+                _google_genai_response(
+                    parts=[_google_genai_part(text="PUSH")],
+                    prompt_token_count=1_000,
+                    candidates_token_count=200,
+                    thoughts_token_count=0,
+                )
+            ),
+            pricing={"input": 5.00, "output": 25.00},
+        )
+        anthropic_metadata = action_metadata_from_model_response(
+            normalize_anthropic_messages_response(
+                _anthropic_response(
+                    content=[SimpleNamespace(type="text", text="PUSH")],
+                    input_tokens=1_000,
+                    output_tokens=200,
+                )
+            ),
+            pricing={"input": 5.00, "output": 25.00},
+        )
+
+        assert gemini_metadata.cost.model_dump() == anthropic_metadata.cost.model_dump()
+        assert gemini_metadata.usage.input_tokens == anthropic_metadata.usage.input_tokens
+        assert gemini_metadata.usage.output_tokens == anthropic_metadata.usage.output_tokens
+        assert gemini_metadata.usage.total_tokens == anthropic_metadata.usage.total_tokens
 
     def test_anthropic_messages_metadata_projection_maps_usage_and_cost(self):
         raw_response = _anthropic_response(

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "arc-agi" },
     { name = "dotenv" },
+    { name = "google-genai" },
     { name = "langchain", extra = ["openai"] },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
@@ -107,6 +108,7 @@ requires-dist = [
     { name = "anthropic", specifier = "==0.95.0" },
     { name = "arc-agi", specifier = ">=0.9.8" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "google-genai", specifier = ">=2.4.0" },
     { name = "langchain", extras = ["openai"], specifier = ">=0.3.27" },
     { name = "langgraph", specifier = ">=0.6.3" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.11" },
@@ -161,35 +163,59 @@ wheels = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178 },
-    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840 },
-    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
-    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
-    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
-    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
-    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
-    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448 },
-    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976 },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989 },
-    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802 },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
-    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271 },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048 },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529 },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097 },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983 },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519 },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572 },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963 },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361 },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932 },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557 },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762 },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230 },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043 },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446 },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101 },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948 },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422 },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499 },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928 },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302 },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909 },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402 },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780 },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320 },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487 },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049 },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793 },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300 },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244 },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828 },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926 },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650 },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687 },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773 },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013 },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354 },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480 },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584 },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443 },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437 },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487 },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726 },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195 },
 ]
 
 [[package]]
@@ -324,6 +350,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587 },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433 },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620 },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283 },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573 },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677 },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808 },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941 },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579 },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326 },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672 },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574 },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868 },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107 },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556 },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776 },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121 },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042 },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526 },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116 },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030 },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640 },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657 },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362 },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580 },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283 },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954 },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313 },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482 },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266 },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228 },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097 },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582 },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479 },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481 },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713 },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165 },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947 },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059 },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575 },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117 },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100 },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -444,6 +523,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597 },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071 },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/91/15fff1b7c22dc0b5b44fa348f151379721353d06a3da22dbbe15bf2c4dd9/google_genai-2.4.0.tar.gz", hash = "sha256:3f8d4bd618be2801e805dc698726731a70f34b438ea25a6c92800eef5b1f513e", size = 552025 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c8/1b49f6bb69dc7e291ba5d14926937bec4dffcc09ee875822636bd5ef3cf4/google_genai-2.4.0-py3-none-any.whl", hash = "sha256:48df1c44190b05b834fee9cffd360af6d6fd7f68164588e7ebd670fa34f71ee1", size = 818207 },
 ]
 
 [[package]]
@@ -1334,6 +1452,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1782,6 +1921,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/2e/8a70dcbe8bf15213a08f9b0325ede04faca5d362922ae0d62ef0fa4b069d/virtualenv-20.33.0.tar.gz", hash = "sha256:47e0c0d2ef1801fce721708ccdf2a28b9403fa2307c3268aebd03225976f61d2", size = 6082069 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/87/b22cf40cdf7e2b2bf83f38a94d2c90c5ad6c304896e5a12d0c08a602eb59/virtualenv-20.33.0-py3-none-any.whl", hash = "sha256:106b6baa8ab1b526d5a9b71165c85c456fbd49b16976c88e2bc9352ee3bc5d3f", size = 6060205 },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365 },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038 },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583 },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261 },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693 },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364 },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039 },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323 },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975 },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203 },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920 },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255 },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406 },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044 },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279 },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711 },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915 },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381 },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737 },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486 },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331 },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501 },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062 },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a Google Gemini runtime adapter alongside the existing OpenAI and Anthropic adapters
- Wires the new client through `runtime_clients` and registers the adapter selection
- Adds unit tests covering the adapter, runtime models, and client wiring

## Test plan
- [ ] Review new adapter implementation in `benchmarking/runtime_adapters.py` and `benchmarking/runtime_models.py`
- [ ] Run the unit test suite (`tests/unit/`)
- [ ] Spot-check an end-to-end run against a Gemini model with a valid API key