### PR TITLE
Update default system prompt

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -175,12 +175,12 @@ class BenchmarkingAgent(Agent):
     def _build_system_prompt(self) -> str:
         if self.analysis_mode:
             return textwrap.dedent("""\
-                You are playing a game. Your goal is to win. Reply with the exact action you want to take. The final action in your reply will be executed next turn. Your entire reply will be carried to the next turn.
+                You are playing a game. Your goal is to win. Include any context you want to carry forward in your reply, along with the action you want to take. The final action mentioned in your reply will be executed next turn.
 
                 Prior assistant turns may include a <reasoning_summary> block before the prior action text. Treat those summaries as compact helper context about the earlier decision process, then continue by choosing the next action normally.
             """)
         return textwrap.dedent("""\
-            You are playing a game. Your goal is to win. Reply with the exact action you want to take. The final action in your reply will be executed next turn. Your entire reply will be carried to the next turn.
+            You are playing a game. Your goal is to win. Include any context you want to carry forward in your reply, along with the action you want to take. The final action mentioned in your reply will be executed next turn.
         """)
 
     def _build_assistant_turn_content(


### PR DESCRIPTION
## Summary
- Updates the default system prompt in `BenchmarkingAgent._build_system_prompt` to explicitly invite the model to include carry-forward context alongside the chosen action.
- Applies the same wording to both the `analysis_mode` and default branches; the `analysis_mode` branch retains its `<reasoning_summary>` paragraph.

New prompt text:
> You are playing a game. Your goal is to win. Include any context you want to carry forward in your reply, along with the action you want to take. The final action mentioned in your reply will be executed next turn.