### PR TITLE
Strip model-emitted <reasoning_summary> blocks in analysis mode

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -27,6 +27,13 @@ from .runtime_models import (
 
 logger = logging.getLogger()
 
+# Matches a <reasoning_summary>…</reasoning_summary> block (any case, multiline).
+# Used to drop blocks the model emits by imitation in analysis mode.
+_REASONING_SUMMARY_BLOCK_RE = re.compile(
+    r"<reasoning_summary>.*?</reasoning_summary>\s*",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 class BenchmarkingAgent(Agent):
     """An agent that maintains a growing conversation with a model runtime.
@@ -190,6 +197,9 @@ class BenchmarkingAgent(Agent):
     ) -> str:
         if not self.analysis_mode or not reasoning_text:
             return output_text
+        # The model sometimes imitates the replayed <reasoning_summary> format in
+        # its own output; strip it so the stored turn keeps only the harness summary.
+        output_text = self._strip_reasoning_summary_blocks(output_text)
         return textwrap.dedent(f"""\
             <reasoning_summary>
             {reasoning_text}
@@ -197,6 +207,16 @@ class BenchmarkingAgent(Agent):
 
             {output_text}
         """)
+
+    @staticmethod
+    def _strip_reasoning_summary_blocks(text: str) -> str:
+        """Remove any <reasoning_summary>…</reasoning_summary> blocks from text.
+
+        Drops blocks the model emits by imitation in analysis mode so they do
+        not stack with the harness-injected summary. Returns the remaining text
+        with surrounding whitespace trimmed.
+        """
+        return _REASONING_SUMMARY_BLOCK_RE.sub("", text).strip()
 
     def _get_actions(self, latest_frame: FrameData) -> list[GameAction]:
         """Convert frame's available_actions (list[int]) to GameAction objects.

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -299,6 +299,32 @@ class TestBenchmarkingAgentModelRequests:
 
         assert agent._build_assistant_turn_content("RESET", reasoning_text) == "RESET"
 
+    def test_build_assistant_turn_content_strips_model_emitted_reasoning_summary(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.analysis_mode = True
+
+        # The model imitated the replayed format and emitted its own block.
+        output_with_mimicked_block = (
+            "<reasoning_summary>\n"
+            "I should keep probing the controls.\n"
+            "</reasoning_summary>\n\n"
+            "Context: still mapping controls.\n\n"
+            "ACTION3"
+        )
+
+        result = agent._build_assistant_turn_content(
+            output_with_mimicked_block,
+            "harness summary text",
+        )
+
+        # Only the harness-injected summary survives, not a stacked duplicate.
+        assert result.count("<reasoning_summary>") == 1
+        assert "harness summary text" in result
+        assert "I should keep probing the controls." not in result
+        # The chosen action and remaining context are preserved.
+        assert "ACTION3" in result
+        assert "Context: still mapping controls." in result
+
     def test_builds_model_request_from_conversation_state(self):
         agent = _agent_for_request_kwargs(
             {"model": "gpt-5.4", "max_completion_tokens": 128}


### PR DESCRIPTION
## Problem

In analysis mode the harness replays each turn's reasoning into context wrapped in `<reasoning_summary>` tags.

Models (e.g. GPT-5.4) sometimes imitate that format and emit their own `<reasoning_summary>` block, which then gets stored alongside the harness-injected one, producing redundant, compounding reasoning blocks on later turns and inflating context tokens.

For example, in [this step 3](https://gist.github.com/mattm/f4d7c4f6759c7249adac809007d4a701) you can see that the `assistant_response` includes `<reasoning_summary>ACTION1 and ACTION2 both changed...</reasoning_summary>` (along with the expected `reasoning` value):

<img width="2186" height="478" alt="image" src="https://github.com/user-attachments/assets/6d20914c-2cbc-4ba4-8560-68784584e067" />

As a result, when the harness builds the conversation history for use in [step 4](https://gist.github.com/mattm/21580bd8abf87e4e3a5f667d7e59f933), the `content` winds up with two `<reasoning_summary>` blocks: the legit harness one _and_ the unexpected one that the model emitted as part of step 3's response.

<img width="2220" height="540" alt="image" src="https://github.com/user-attachments/assets/c11cc11e-3848-4572-8fcc-986053e5c337" />

This is not terribly consequential, but the conversation history would be cleaner if the harness automatically stripped any reasoning summaries that the model incorrectly output in its response.

## Fix

To tidy things up, this PR strips model-emitted `<reasoning_summary>` blocks from `output_text` before wrapping, so each stored assistant turn carries exactly one (harness) summary. Action parsing is unaffected (it runs on the raw response). This PR also adds a unit test covering the new behavior.

## Validation

[ ] `uv run pytest tests/unit` // 207 passed
[ ] `uv run ruff check benchmarking/agent.py tests/unit/test_benchmarking_agent.py` // all checks passed
[ ] `git diff main --check` // no whitespace/conflict-marker issues