### PR TITLE
Server-managed OpenAI Responses state (previous_response_id + compaction)

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -13,7 +13,7 @@ from arcengine import FrameData, GameAction, GameState
 
 from .base import Agent
 from .exceptions import EmptyResponseError
-from .model_config import get_model_config
+from .model_config import SERVER_RUNTIME_STATE, get_model_config
 from .recording import RunRecord, StepRecord, StepUsage
 from .runtime_adapters import build_model_runtime_adapter
 from .runtime_clients import build_model_runtime_client
@@ -62,6 +62,16 @@ class BenchmarkingAgent(Agent):
             self._load_model_config()
         )
         self._pricing: dict[str, float] = pricing_cfg
+
+        # Server-managed conversation state (OpenAI Responses previous_response_id
+        # + compaction). When enabled, we send only the new message(s) each turn
+        # and let OpenAI hold the transcript; `self.conversation` becomes a
+        # recording-only mirror and client-side trimming is disabled.
+        self._server_state: bool = (
+            runtime_cfg.get("state") == SERVER_RUNTIME_STATE
+        )
+        self._previous_response_id: str | None = None
+        self._pending_user_messages: list[dict[str, Any]] = []
 
         # Agent-level overrides
         self.MAX_ACTIONS_BASELINE_MULTIPLIER = agent_cfg.get(
@@ -353,9 +363,32 @@ class BenchmarkingAgent(Agent):
         logger.info(f"Saved step {self.step_counter} to {filename}")
 
     def _build_model_request(self) -> ModelRequest:
+        if self._server_state:
+            return self._build_server_state_request()
         return ModelRequest(
             messages=[Message.model_validate(message) for message in self.conversation],
             request_config=dict(self._request_kwargs),
+        )
+
+    def _build_server_state_request(self) -> ModelRequest:
+        """Build a request that sends only the new turn(s) to OpenAI.
+
+        On the first turn (no prior response id) the system prompt is sent as a
+        leading system message; thereafter only the buffered user message(s) are
+        sent, with ``previous_response_id`` carrying the server-side state.
+        """
+        request_config = dict(self._request_kwargs)
+        messages: list[dict[str, Any]] = []
+        if self._previous_response_id is None:
+            messages.append(
+                {"role": "system", "content": self._build_system_prompt()}
+            )
+        else:
+            request_config["previous_response_id"] = self._previous_response_id
+        messages.extend(self._pending_user_messages)
+        return ModelRequest(
+            messages=[Message.model_validate(message) for message in messages],
+            request_config=request_config,
         )
 
     def _record_forced_action_observation(
@@ -368,12 +401,15 @@ class BenchmarkingAgent(Agent):
         self._level_action_counter += 1
 
         if forced_action == GameAction.RESET and latest_frame.state is GameState.GAME_OVER:
-            self.conversation.append(
-                {
-                    "role": "user",
-                    "content": self.build_frame_content(latest_frame),
-                }
-            )
+            frame_message = {
+                "role": "user",
+                "content": self.build_frame_content(latest_frame),
+            }
+            self.conversation.append(frame_message)
+            # This observation reaches the model only on the next real API call,
+            # so buffer it for server-managed state too.
+            if self._server_state:
+                self._pending_user_messages.append(frame_message)
 
         self._save_step(
             StepRecord(
@@ -451,9 +487,13 @@ class BenchmarkingAgent(Agent):
             )
 
         # Normal turn: append frame, call the model, parse action
-        self.conversation.append(
-            {"role": "user", "content": self.build_frame_content(latest_frame)}
-        )
+        frame_message = {
+            "role": "user",
+            "content": self.build_frame_content(latest_frame),
+        }
+        self.conversation.append(frame_message)
+        if self._server_state:
+            self._pending_user_messages.append(frame_message)
 
         actions = self._get_actions(latest_frame)
         start = time.monotonic()
@@ -462,6 +502,12 @@ class BenchmarkingAgent(Agent):
         )
         duration = round(time.monotonic() - start, 3)
         step_usage = StepUsage.from_normalized_usage(model_response.usage)
+
+        # On success, advance server-side state and flush the pending buffer so
+        # the next turn sends only its new message(s).
+        if self._server_state:
+            self._previous_response_id = model_response.response_id
+            self._pending_user_messages = []
 
         self.conversation.append(
             {
@@ -545,7 +591,10 @@ class BenchmarkingAgent(Agent):
         accumulated_usage = NormalizedUsage()
         for attempt in range(self.MAX_RETRIES + 1):
             try:
-                self._trim_to_fit_context()
+                # Server-managed state compacts on OpenAI's side; the docs say not
+                # to manually prune when chaining via previous_response_id.
+                if not self._server_state:
+                    self._trim_to_fit_context()
                 model_request = self._build_model_request()
                 model_response = self._call_api(model_request)
             except EmptyResponseError as e:

--- a/benchmarking/model_config.py
+++ b/benchmarking/model_config.py
@@ -13,7 +13,16 @@ SUPPORTED_RUNTIME_PAIRS = frozenset(
         ("openai-python", "responses"),
     }
 )
-SUPPORTED_RUNTIME_STATE = "manual_rolling"
+DEFAULT_RUNTIME_STATE = "manual_rolling"
+SERVER_RUNTIME_STATE = "previous_response_id"
+# Backwards-compatible alias: most call sites and tests reference the default.
+SUPPORTED_RUNTIME_STATE = DEFAULT_RUNTIME_STATE
+SUPPORTED_RUNTIME_STATES = frozenset(
+    {DEFAULT_RUNTIME_STATE, SERVER_RUNTIME_STATE}
+)
+# Server-managed conversation state (previous_response_id + compaction) is only
+# available on the OpenAI Responses runtime.
+SERVER_STATE_RUNTIME_PAIRS = frozenset({("openai-python", "responses")})
 ANTHROPIC_OPENAI_COMPAT_CLIENT_FIELDS = frozenset({"base_url"})
 ANTHROPIC_OPENAI_COMPAT_REQUEST_FIELDS = frozenset(
     {
@@ -127,10 +136,21 @@ def _validate_model_config_entry(entry: Any, index: int, seen_ids: set[str]) -> 
             f"(sdk={runtime['sdk']!r}, api={runtime['api']!r}). "
             f"Supported runtimes: {_format_supported_runtime_pairs()}."
         )
-    if runtime.get("state") != SUPPORTED_RUNTIME_STATE:
+    runtime_state = runtime.get("state")
+    if runtime_state not in SUPPORTED_RUNTIME_STATES:
+        supported = ", ".join(repr(s) for s in sorted(SUPPORTED_RUNTIME_STATES))
         raise ValueError(
-            f"Model config '{config_id}' uses runtime.state={runtime.get('state')!r}, "
-            f"but only '{SUPPORTED_RUNTIME_STATE}' is supported."
+            f"Model config '{config_id}' uses runtime.state={runtime_state!r}, "
+            f"but only {supported} are supported."
+        )
+    if (
+        runtime_state == SERVER_RUNTIME_STATE
+        and runtime_pair not in SERVER_STATE_RUNTIME_PAIRS
+    ):
+        raise ValueError(
+            f"Model config '{config_id}' uses runtime.state={SERVER_RUNTIME_STATE!r}, "
+            f"which is only supported on the OpenAI Responses runtime "
+            f"(sdk='openai-python', api='responses')."
         )
     if runtime_pair == ("anthropic-python", "messages"):
         _validate_anthropic_messages_config(config_id, entry)

--- a/benchmarking/runtime_adapters.py
+++ b/benchmarking/runtime_adapters.py
@@ -13,7 +13,15 @@ from .runtime_models import (
     normalize_responses_response,
 )
 
-SUPPORTED_RUNTIME_STATE = "manual_rolling"
+DEFAULT_RUNTIME_STATE = "manual_rolling"
+SERVER_RUNTIME_STATE = "previous_response_id"
+# Backwards-compatible alias for the default (client-managed) state.
+SUPPORTED_RUNTIME_STATE = DEFAULT_RUNTIME_STATE
+SUPPORTED_RUNTIME_STATES = frozenset(
+    {DEFAULT_RUNTIME_STATE, SERVER_RUNTIME_STATE}
+)
+# Server-managed state is only available on the OpenAI Responses runtime.
+SERVER_STATE_RUNTIME_KEYS = frozenset({("openai-python", "responses")})
 
 
 class ModelRuntimeAdapter(Protocol):
@@ -41,6 +49,60 @@ class OpenAIResponsesAdapter:
         request_kwargs = dict(request.request_config)
         request_kwargs.pop("previous_response_id", None)
         request_kwargs.pop("conversation", None)
+
+        messages = [message.model_dump() for message in request.messages]
+        if request.messages and request.messages[0].role == "system":
+            request_kwargs["instructions"] = request.messages[0].content
+            request_kwargs["input"] = messages[1:]
+            return request_kwargs
+
+        request_kwargs["input"] = messages
+        return request_kwargs
+
+    def invoke(self, request: ModelRequest) -> ModelResponse:
+        raw_response = self._client.responses.create(
+            **self._build_request_kwargs(request),
+        )
+        return normalize_responses_response(raw_response)
+
+
+class OpenAIResponsesServerStateAdapter:
+    """OpenAI Responses adapter using server-managed conversation state.
+
+    Instead of resending the whole transcript, the caller sends only the new
+    message(s) for this turn plus a ``previous_response_id`` (in the request
+    config). OpenAI holds the conversation state, and long runs are kept in
+    budget by server-side compaction (``context_management`` /
+    ``compact_threshold``).
+
+    Requires ``store=true`` so the response chain resolves server-side; this
+    runtime therefore needs a non-ZDR key.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @staticmethod
+    def _build_request_kwargs(request: ModelRequest) -> dict[str, Any]:
+        request_kwargs = dict(request.request_config)
+
+        # store=true is required for previous_response_id chaining.
+        request_kwargs.setdefault("store", True)
+
+        # Translate our compaction knob into the API's structured parameter.
+        # `context_management` is newer than the pinned SDK's typed signature, so
+        # send it via extra_body to avoid an SDK version bump.
+        compact_threshold = request_kwargs.pop("compact_threshold", None)
+        if compact_threshold is not None:
+            extra_body = dict(request_kwargs.pop("extra_body", {}) or {})
+            extra_body["context_management"] = [
+                {"type": "compaction", "compact_threshold": compact_threshold}
+            ]
+            request_kwargs["extra_body"] = extra_body
+
+        # Drop a null previous_response_id on the first turn so we never send it.
+        if request_kwargs.get("previous_response_id") is None:
+            request_kwargs.pop("previous_response_id", None)
 
         messages = [message.model_dump() for message in request.messages]
         if request.messages and request.messages[0].role == "system":
@@ -227,13 +289,24 @@ def build_model_runtime_adapter(
     config_id: str,
 ) -> ModelRuntimeAdapter:
     runtime_state = runtime_config.get("state")
-    if runtime_state != SUPPORTED_RUNTIME_STATE:
+    if runtime_state not in SUPPORTED_RUNTIME_STATES:
+        supported = ", ".join(repr(s) for s in sorted(SUPPORTED_RUNTIME_STATES))
         raise ValueError(
             f"Model config '{config_id}' uses runtime.state={runtime_state!r}, "
-            f"but only '{SUPPORTED_RUNTIME_STATE}' is supported in phase 3."
+            f"but only {supported} are supported."
         )
 
     runtime_key = (runtime_config.get("sdk"), runtime_config.get("api"))
+
+    if runtime_state == SERVER_RUNTIME_STATE:
+        if runtime_key not in SERVER_STATE_RUNTIME_KEYS:
+            raise ValueError(
+                f"Model config '{config_id}' uses runtime.state={SERVER_RUNTIME_STATE!r}, "
+                f"which is only supported on the OpenAI Responses runtime "
+                f"(sdk='openai-python', api='responses')."
+            )
+        return OpenAIResponsesServerStateAdapter(client)
+
     if runtime_key == ("openai-python", "chat_completions"):
         return OpenAIChatCompletionsAdapter(client)
     if runtime_key == ("openai-python", "responses"):

--- a/benchmarking/runtime_models.py
+++ b/benchmarking/runtime_models.py
@@ -60,6 +60,9 @@ class ModelResponse(BaseModel):
     reasoning_text: str | None = None
     usage: NormalizedUsage
     raw_response: Any | None = None
+    # Server-side response identifier (OpenAI Responses API). Used to chain
+    # turns via previous_response_id when runtime.state == "previous_response_id".
+    response_id: str | None = None
 
 
 def _value_from_response_object(item: Any, key: str, default: Any = None) -> Any:
@@ -366,6 +369,7 @@ def normalize_responses_response(response: Any) -> ModelResponse:
             )
         ),
         raw_response=response,
+        response_id=_value_from_response_object(response, "id"),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "langgraph>=0.6.3",
     "langgraph-checkpoint-sqlite>=2.0.11",
     "numpy>=2.3.2",
-    "openai==1.72.0",
+    "openai==2.41.1",
     "pillow>=11.2.1",
     "pydantic>=2.11.7",
     "requests>=2.32.4",

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -62,6 +62,9 @@ def _agent_for_request_kwargs(request_kwargs: dict) -> BenchmarkingAgent:
     agent.MAX_RETRIES = 2
     agent.analysis_mode = False
     agent.token_counter = 0
+    agent._server_state = False
+    agent._previous_response_id = None
+    agent._pending_user_messages = []
     return agent
 
 
@@ -877,6 +880,201 @@ class TestBenchmarkingAgentAnalysisReplayIntegration:
             {"role": "assistant", "content": "ACTION1"},
             {"role": "user", "content": agent.build_frame_content(second_frame)},
         ]
+
+
+def _server_state_agent(
+    responses: list[ModelResponse],
+) -> BenchmarkingAgent:
+    agent = _agent_for_choose_action(analysis_mode=False, responses=responses)
+    agent._server_state = True
+    agent._previous_response_id = None
+    agent._pending_user_messages = []
+    return agent
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentServerState:
+    def test_first_turn_sends_system_and_frame_without_previous_response_id(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                )
+            ]
+        )
+        frame = _playable_frame()
+
+        action = agent.choose_action([], frame)
+
+        assert action == GameAction.ACTION1
+        request = agent._adapter.requests[0]
+        assert [m.model_dump() for m in request.messages] == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(frame)},
+        ]
+        assert "previous_response_id" not in request.request_config
+        # Successful turn advances server-side state and flushes the buffer.
+        assert agent._previous_response_id == "resp_1"
+        assert agent._pending_user_messages == []
+
+    def test_second_turn_sends_only_new_frame_with_previous_response_id(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                ),
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=11),
+                    response_id="resp_2",
+                ),
+            ]
+        )
+        first_frame = _playable_frame()
+        second_frame = _playable_frame()
+
+        agent.choose_action([], first_frame)
+        agent.choose_action([first_frame], second_frame)
+
+        second_request = agent._adapter.requests[1]
+        assert [m.model_dump() for m in second_request.messages] == [
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+        ]
+        assert second_request.request_config["previous_response_id"] == "resp_1"
+        assert agent._previous_response_id == "resp_2"
+        # messages_sent records only what was actually sent that turn.
+        assert agent._saved_steps[1].messages_sent == [
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+        ]
+
+    def test_conversation_mirror_still_records_full_transcript(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                ),
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=11),
+                    response_id="resp_2",
+                ),
+            ]
+        )
+        first_frame = _playable_frame()
+        second_frame = _playable_frame()
+
+        agent.choose_action([], first_frame)
+        agent.choose_action([first_frame], second_frame)
+
+        assert agent.conversation == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(first_frame)},
+            {"role": "assistant", "content": "ACTION1"},
+            {"role": "user", "content": agent.build_frame_content(second_frame)},
+            {"role": "assistant", "content": "ACTION1"},
+        ]
+
+    def test_forced_reset_observation_is_buffered_into_next_real_turn(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                ),
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=11),
+                    response_id="resp_2",
+                ),
+            ]
+        )
+        agent.action_counter = 1
+        game_over_frame = _terminal_frame(GameState.GAME_OVER)
+
+        # Forced RESET: records an observation but makes no API call.
+        forced = agent._resolve_action([], game_over_frame)
+        assert forced == GameAction.RESET
+        assert agent._adapter.requests == []
+        assert len(agent._pending_user_messages) == 1
+
+        # Next real turn must include the buffered GAME_OVER observation first.
+        next_frame = _playable_frame()
+        agent.choose_action([], next_frame)
+
+        first_request = agent._adapter.requests[0]
+        assert [m.model_dump() for m in first_request.messages] == [
+            {"role": "system", "content": agent._build_system_prompt()},
+            {"role": "user", "content": agent.build_frame_content(game_over_frame)},
+            {"role": "user", "content": agent.build_frame_content(next_frame)},
+        ]
+        assert agent._pending_user_messages == []
+
+    def test_retries_do_not_advance_previous_response_id(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                ),
+                # Turn 2, attempt 1: no parseable action -> retried.
+                ModelResponse(
+                    output_text="no action here",
+                    usage=NormalizedUsage(total_tokens=5),
+                    response_id="resp_orphan",
+                ),
+                # Turn 2, attempt 2: valid action.
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=11),
+                    response_id="resp_2",
+                ),
+            ]
+        )
+        first_frame = _playable_frame()
+        second_frame = _playable_frame()
+
+        agent.choose_action([], first_frame)
+        agent.choose_action([first_frame], second_frame)
+
+        # Both turn-2 attempts chain off turn 1, not off the orphaned attempt.
+        retry_requests = agent._adapter.requests[1:]
+        assert len(retry_requests) == 2
+        for request in retry_requests:
+            assert request.request_config["previous_response_id"] == "resp_1"
+            assert [m.model_dump() for m in request.messages] == [
+                {"role": "user", "content": agent.build_frame_content(second_frame)},
+            ]
+        # Only the successful response advances the chain.
+        assert agent._previous_response_id == "resp_2"
+
+    def test_server_state_skips_client_side_trimming(self):
+        agent = _server_state_agent(
+            [
+                ModelResponse(
+                    output_text="ACTION1",
+                    usage=NormalizedUsage(total_tokens=9),
+                    response_id="resp_1",
+                )
+            ]
+        )
+        agent.MAX_CONTEXT_LENGTH = 1  # Would force trimming if it were applied.
+
+        def _fail_if_called() -> None:
+            raise AssertionError("client-side trimming must not run in server state")
+
+        agent._trim_to_fit_context = _fail_if_called
+
+        action = agent.choose_action([], _playable_frame())
+
+        assert action == GameAction.ACTION1
 
 
 def _agent_with_env(step_frame: FrameData) -> BenchmarkingAgent:

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -276,6 +276,56 @@ class TestModelConfig:
         ):
             model_config.load_model_configs()
 
+    def test_load_model_configs_accepts_server_state_for_responses_runtime(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "responses-server-state",
+                    runtime={
+                        "sdk": "openai-python",
+                        "api": "responses",
+                        "state": "previous_response_id",
+                    },
+                )
+            ],
+        )
+
+        configs = model_config.load_model_configs()
+
+        assert configs[0]["runtime"]["state"] == "previous_response_id"
+
+    def test_load_model_configs_rejects_unknown_runtime_state(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "bad-state",
+                    runtime={
+                        "sdk": "openai-python",
+                        "api": "responses",
+                        "state": "totally_made_up",
+                    },
+                )
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="uses runtime.state='totally_made_up'",
+        ):
+            model_config.load_model_configs()
+
     def test_load_model_configs_accepts_boolean_analysis_mode(
         self,
         tmp_path,

--- a/tests/unit/test_runtime_adapters.py
+++ b/tests/unit/test_runtime_adapters.py
@@ -9,6 +9,7 @@ from benchmarking.runtime_adapters import (
     GoogleGenAIGenerateContentAdapter,
     OpenAIChatCompletionsAdapter,
     OpenAIResponsesAdapter,
+    OpenAIResponsesServerStateAdapter,
     build_model_runtime_adapter,
 )
 from benchmarking.runtime_models import Message, ModelRequest
@@ -570,6 +571,141 @@ class TestOpenAIResponsesAdapter:
 
         assert "previous_response_id" not in client.responses.calls[0]
         assert "conversation" not in client.responses.calls[0]
+
+
+@pytest.mark.unit
+class TestOpenAIResponsesServerStateAdapter:
+    def test_first_turn_sends_system_as_instructions_and_only_new_message(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[
+                    Message(role="system", content="System prompt"),
+                    Message(role="user", content="frame 1"),
+                ],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        call = client.responses.calls[0]
+        assert call["instructions"] == "System prompt"
+        assert call["input"] == [{"role": "user", "content": "frame 1"}]
+        # No prior response yet, so previous_response_id must not be sent.
+        assert "previous_response_id" not in call
+
+    def test_subsequent_turn_sends_previous_response_id_and_only_new_message(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame 2")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_123",
+                },
+            )
+        )
+
+        call = client.responses.calls[0]
+        assert call["previous_response_id"] == "resp_123"
+        assert call["input"] == [{"role": "user", "content": "frame 2"}]
+        assert "instructions" not in call
+
+    def test_defaults_store_to_true(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        assert client.responses.calls[0]["store"] is True
+
+    def test_preserves_explicit_store_value(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={"model": "gpt-5.4", "store": False},
+            )
+        )
+
+        assert client.responses.calls[0]["store"] is False
+
+    def test_translates_compact_threshold_to_context_management(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={"model": "gpt-5.4", "compact_threshold": 200_000},
+            )
+        )
+
+        call = client.responses.calls[0]
+        # context_management ships via extra_body (newer than the pinned SDK sig).
+        assert call["extra_body"]["context_management"] == [
+            {"type": "compaction", "compact_threshold": 200_000}
+        ]
+        # The raw knob must not leak through to the API call.
+        assert "compact_threshold" not in call
+
+    def test_compaction_merges_with_existing_extra_body(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={
+                    "model": "gpt-5.4",
+                    "compact_threshold": 200_000,
+                    "extra_body": {"foo": "bar"},
+                },
+            )
+        )
+
+        extra_body = client.responses.calls[0]["extra_body"]
+        assert extra_body["foo"] == "bar"
+        assert extra_body["context_management"] == [
+            {"type": "compaction", "compact_threshold": 200_000}
+        ]
+
+    def test_omits_compaction_when_no_threshold_configured(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={"model": "gpt-5.4"},
+            )
+        )
+
+        assert "context_management" not in client.responses.calls[0]
+        assert "extra_body" not in client.responses.calls[0]
+
+    def test_drops_null_previous_response_id(self):
+        client = _FakeResponsesOpenAIClient(_responses_output())
+        adapter = OpenAIResponsesServerStateAdapter(client)
+
+        adapter.invoke(
+            ModelRequest(
+                messages=[Message(role="user", content="frame")],
+                request_config={"model": "gpt-5.4", "previous_response_id": None},
+            )
+        )
+
+        assert "previous_response_id" not in client.responses.calls[0]
 
 
 @pytest.mark.unit
@@ -1193,12 +1329,30 @@ class TestBuildModelRuntimeAdapter:
         assert isinstance(chat_adapter, OpenAIChatCompletionsAdapter)
         assert isinstance(responses_adapter, OpenAIResponsesAdapter)
 
-    def test_unsupported_runtime_state_fails_clearly(self):
+    def test_unknown_runtime_state_fails_clearly(self):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Model config 'chat-config' uses runtime.state='bogus_state', "
+                "but only"
+            ),
+        ):
+            build_model_runtime_adapter(
+                client=_FakeChatOpenAIClient(_chat_response()),
+                runtime_config={
+                    "sdk": "openai-python",
+                    "api": "chat_completions",
+                    "state": "bogus_state",
+                },
+                config_id="chat-config",
+            )
+
+    def test_server_state_rejected_for_non_responses_runtime(self):
         with pytest.raises(
             ValueError,
             match=(
                 "Model config 'chat-config' uses runtime.state='previous_response_id', "
-                "but only 'manual_rolling' is supported in phase 3."
+                "which is only supported on the OpenAI Responses runtime"
             ),
         ):
             build_model_runtime_adapter(
@@ -1210,3 +1364,16 @@ class TestBuildModelRuntimeAdapter:
                 },
                 config_id="chat-config",
             )
+
+    def test_selects_server_state_adapter_for_responses_runtime(self):
+        adapter = build_model_runtime_adapter(
+            client=_FakeResponsesOpenAIClient(_responses_output()),
+            runtime_config={
+                "sdk": "openai-python",
+                "api": "responses",
+                "state": "previous_response_id",
+            },
+            config_id="responses-server-state-config",
+        )
+
+        assert isinstance(adapter, OpenAIResponsesServerStateAdapter)

--- a/tests/unit/test_runtime_models.py
+++ b/tests/unit/test_runtime_models.py
@@ -257,6 +257,19 @@ class TestRuntimeModels:
         )
         assert model_response.usage.total_tokens == 18
 
+    def test_responses_normalizer_extracts_response_id_when_present(self):
+        raw_response = _responses_response()
+        raw_response.id = "resp_abc123"
+
+        model_response = normalize_responses_response(raw_response)
+
+        assert model_response.response_id == "resp_abc123"
+
+    def test_responses_normalizer_response_id_is_none_when_absent(self):
+        model_response = normalize_responses_response(_responses_response())
+
+        assert model_response.response_id is None
+
     def test_responses_metadata_projection_maps_reasoning_usage_and_cost(self):
         raw_response = SimpleNamespace(
             output=[

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.3" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.11" },
     { name = "numpy", specifier = ">=2.3.2" },
-    { name = "openai", specifier = "==1.72.0" },
+    { name = "openai", specifier = "==2.41.1" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "requests", specifier = ">=2.32.4" },
@@ -882,7 +882,7 @@ openai = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.72"
+version = "0.3.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -892,24 +892,25 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
+    { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/49/7568baeb96a57d3218cb5f1f113b142063679088fd3a0d0cae1feb0b3d36/langchain_core-0.3.72.tar.gz", hash = "sha256:4de3828909b3d7910c313242ab07b241294650f5cb6eac17738dd3638b1cd7de", size = 567227 }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8d/d54586b8f65c6fc209db93916ff9e919e1cc14bad8fe66880ea4d7ea9d6c/langchain_core-0.3.86.tar.gz", hash = "sha256:671cbc96a325fe47f7dbab421236ada2d437bc4bfad0038102264885d0b462e2", size = 603154 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/7d/9f75023c478e3b854d67da31d721e39f0eb30ae969ec6e755430cb1c0fb5/langchain_core-0.3.72-py3-none-any.whl", hash = "sha256:9fa15d390600eb6b6544397a7aa84be9564939b6adf7a2b091179ea30405b240", size = 442806 },
+    { url = "https://files.pythonhosted.org/packages/0c/93/ba19ca54701c6118e68f8785949b6c0eab1df3a5cfa5310508cc86877994/langchain_core-0.3.86-py3-none-any.whl", hash = "sha256:7d2a1c50d2d2a139dbc6465cd339f32d14aa43db5ac9bd232e5b567a238709e8", size = 461306 },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.23"
+version = "0.3.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/f1/575120e829430f9bdcfc2c5c4121f04b1b5a143d96e572ff32399b787ef2/langchain_openai-0.3.23.tar.gz", hash = "sha256:73411c06e04bc145db7146a6fcf33dd0f1a85130499dcae988829a4441ddaa66", size = 647923 }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/96/06d0d25a37e05a0ff2d918f0a4b0bf0732aed6a43b472b0b68426ce04ef8/langchain_openai-0.3.35.tar.gz", hash = "sha256:fa985fd041c3809da256a040c98e8a43e91c6d165b96dcfeb770d8bd457bf76f", size = 786635 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/65/88060305d5d627841bc8da7e9fb31fb603e5b103b4e5ec5b4d1a7edfbc3b/langchain_openai-0.3.23-py3-none-any.whl", hash = "sha256:624794394482c0923823f0aac44979968d77fdcfa810e42d4b0abd8096199a40", size = 65392 },
+    { url = "https://files.pythonhosted.org/packages/d8/d5/c90c5478215c20ee71d8feaf676f7ffd78d0568f8c98bd83f81ce7562ed7/langchain_openai-0.3.35-py3-none-any.whl", hash = "sha256:76d5707e6e81fd461d33964ad618bd326cb661a1975cef7c1cb0703576bdada5", size = 75952 },
 ]
 
 [[package]]
@@ -1240,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.72.0"
+version = "2.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1252,9 +1253,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/56/41de36c0e9f787c406211552ecf2ca4fba3db900207c5c158c4dc67263fc/openai-1.72.0.tar.gz", hash = "sha256:f51de971448905cc90ed5175a5b19e92fd94e31f68cde4025762f9f5257150db", size = 426061 }
+sdist = { url = "https://files.pythonhosted.org/packages/40/36/4c926a91554483977608951360c18c2e911592785eb87a6437813f6123f7/openai-2.41.1.tar.gz", hash = "sha256:23d617a0432457ad844973bee8f540be9da90894f7c5686852d2d365da058f57", size = 783584 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/1c/a0870f31bd71244c8c3a82e171677d9a148a8ea1cb157308cb9e06a41a37/openai-1.72.0-py3-none-any.whl", hash = "sha256:34f5496ba5c8cb06c592831d69e847e2d164526a2fb92afdc3b5cf2891c328c3", size = 643863 },
+    { url = "https://files.pythonhosted.org/packages/20/74/925d7b3892927e9804aaf58d374a45dc28e4420ff90e992272b77286343e/openai-2.41.1-py3-none-any.whl", hash = "sha256:a939565f350cb7443cb843b801b88c716ac8024b492fb94ca269d5f6b1bbefd6", size = 1353380 },
 ]
 
 [[package]]
@@ -1907,6 +1908,84 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/a1/822ceef22d1c139cffebe4b1b660cfaa10253d5c770aa2598dc8e9497593/uuid_utils-0.16.0.tar.gz", hash = "sha256:d6902d4375dfba4c9902c736bb82d3c040417b67f7d0fa48910ddfdb1ac95de7", size = 42596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/4c/b4cf43a5d22bcdb91727acdf54be0d78e83e595b73c5a9a8a4291875f059/uuid_utils-0.16.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:727fae3f0682191ec9c8ce1cd0f71e81b471a2e26b7c5fd66712fc0f11640aa0", size = 562183 },
+    { url = "https://files.pythonhosted.org/packages/d6/fb/4b0d1c4b5e9f8679ca41b9cdbce5749e1d5db3d3d42a07060d6ce61ac583/uuid_utils-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66a9c8cedf7695c28e700f6a66bde0809c3b2e0d8a70968be7bfd47c908952e5", size = 289018 },
+    { url = "https://files.pythonhosted.org/packages/de/43/2dc6c7401c8fab86e46b0b33ada6dcfde949b2fd48877ba6f880862be80e/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9152bff801ec2ccf630df06d67389090a2c612dea87fbf9a887ab4b222929f6f", size = 326171 },
+    { url = "https://files.pythonhosted.org/packages/9b/f5/48f11fb91f36453611ca148bc441436f279870b1ec6b576dc5167fb6e680/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06fc7db470c37e5c1ab3fd2cd159697d6f8b279d7d23b5b96bd418b115f8caa9", size = 332222 },
+    { url = "https://files.pythonhosted.org/packages/30/cb/b2b49528521e4a097f129e8bf7850a26f00af46afba778832cf3458a5c00/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e1a1f57fe3631e164dad27b24aa81267810e20575f705af3b0fa734f3a21247", size = 444801 },
+    { url = "https://files.pythonhosted.org/packages/a9/b3/a28d9c6f7c701dfe01c8020b30e33899a28eb9e4d056b07e7388f50ebf67/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ee392fe59808a731b7b6bf4d453fb6e833774921331cceae5f254d1e9c5b97d", size = 325594 },
+    { url = "https://files.pythonhosted.org/packages/cf/65/e1ff41dc44966e396ead86e104ba21b35ddb07ff7a64bb55013074ee77fe/uuid_utils-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b2e981b1258db444df4cf4bf4c79673570d081d48d35f22d0f86471e0ad795c5", size = 349312 },
+    { url = "https://files.pythonhosted.org/packages/ed/57/fb19b7951f66a46e03bd1943a61ee9d59c83e994e56e8c97d79aff1f0e47/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bbb92feb4db08cd76e27b4d3b1a82bfde708447317150c614eb9f761a43b387e", size = 502115 },
+    { url = "https://files.pythonhosted.org/packages/2f/8e/9a129c469b7b77afb62da5c6b7e92591073b845bd0c3108c0d0aa65389fb/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c3c5afaaa68b1d6393d653e9fc93a2fde9da1681da01f74b4593f41d31fb5f1", size = 607433 },
+    { url = "https://files.pythonhosted.org/packages/4a/56/2ef71fad168cc3d894f7094fa458086c093635d7835381c91470b19c9ad3/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:38126b353527c5f001e4b24db9e62351eb768d0367febcd68100a4b39a035109", size = 566076 },
+    { url = "https://files.pythonhosted.org/packages/95/bf/68e60ea053ca30f35df877b96001331398140d5c4983561affa1350331b1/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41a67e546d9adf11c4e4cb5c8e81f000f8b1f000c17912ced089b499855719a5", size = 530645 },
+    { url = "https://files.pythonhosted.org/packages/42/19/b521f7d73094fca4c0c44002f4a42bfcbcf0b770fdc3c4b9a596dda25734/uuid_utils-0.16.0-cp312-cp312-win32.whl", hash = "sha256:52d2cc8c12a3466cd1727883e0746d8bad5dddd670369eb553ba17fdc3b565ca", size = 168887 },
+    { url = "https://files.pythonhosted.org/packages/87/1f/4126c3ccbc2d98a613664e55f6ab6d7bd4b98424a04486e4fcc76549af15/uuid_utils-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97625e5edfda8b118160ce1e88756f92b1635775f836c168be7bf10928d97fa", size = 174607 },
+    { url = "https://files.pythonhosted.org/packages/74/62/b83ccc8446ae39dcc0bda2cb3b525b6af6a2036383afe1d1d5fe7b234c2c/uuid_utils-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:baf79c8050eb784b252dd34807df73f61130fe8676b61231baccab62530f20ec", size = 173021 },
+    { url = "https://files.pythonhosted.org/packages/60/9b/74c1f47a9b4f138a254e51528e5ffaeba6bf99ecead9f0c4b6fccccfbfcb/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d34cf9681e8892fad2a63e393068e544505408748cd8bf0c3517d753a01528d4", size = 563166 },
+    { url = "https://files.pythonhosted.org/packages/7c/1c/009e37b70f1f0ff17e7103a36bafde33d503d9ea7fe739761aa3e3c9fde6/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0681d1bdb7956e0c6d581e7601dabcfb2b08c25d2a65189f4e9b102c94f5ff46", size = 289529 },
+    { url = "https://files.pythonhosted.org/packages/5e/5e/e0323d54321166639eb2be5e8a464f5cb0fc04d72d91f3e78944bb6a1da8/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed45fb8732d216426227096b55accbb87cba57febc86a044d90780b090eb99d0", size = 326328 },
+    { url = "https://files.pythonhosted.org/packages/f0/a3/046f6cb958467c3bf4a163a8a53b178b64a62e21ed8ad5b2c1dacb3a2cfc/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b617a334bb01ef2ff8c22900f5a14125eb9063f602131494cc9dc59519beaa5b", size = 332322 },
+    { url = "https://files.pythonhosted.org/packages/67/80/01914e3949744db7acd0006885e5542fbebb6e39114857d007d29b3265c2/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a750d8aeb8ae880aa9a2529606bde0e994bcc7448730c953107f357a28e6102e", size = 445787 },
+    { url = "https://files.pythonhosted.org/packages/14/ef/f6908f41279f205d70c8a0d5dcb25dd6802741d7f88e3f0123453c3584d3/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a250e111903c4368745fce5ac2aa607bd477c62d3307e45347338fdb64b38e0", size = 324678 },
+    { url = "https://files.pythonhosted.org/packages/11/4a/bf841ba90f829c7779d82155e0f4b88ef6726ccc25507d064d50ac2cd329/uuid_utils-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:95b7f480010ea98a29ee809857a98aa923008c68129af1b39244adccff7377fb", size = 349704 },
+    { url = "https://files.pythonhosted.org/packages/e6/31/3b5c60172b8c57bf4ca485484b8e4edef550ca324f9287f1183be97422e2/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:420aa3ca403cedb73490b6ea3aeefeea7e0455f5ce60bbf856390ee872ae3306", size = 502456 },
+    { url = "https://files.pythonhosted.org/packages/88/bf/3da8d497af80fd51d8bf85551c77ede67f07825924ec5987bf9b6031014a/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b8a9a7b1065a12d40f2cc25b7d705ab34954cc57095034367bca39ebcf4a876b", size = 607727 },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/7c8cf03ec15cd6f40e4cbab81b2b4a625461327f68c7971e54723280ec3e/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f235ac5827d74ac630cc87f29278cdaa5d2f273613a6e05bbd96df7aa4170776", size = 566204 },
+    { url = "https://files.pythonhosted.org/packages/f9/5f/af955feae69cce7fd2121ca3f790ff4b85ad2e17b2149546f50753e1a047/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c8083284488b84ad178e74add64cfd1e74e8be5e30821e5acbc5019281c658b0", size = 529986 },
+    { url = "https://files.pythonhosted.org/packages/10/cf/3fec757e51bef10eb41ae8075f5442c60e85ff456b42d16a3063f5dc6c80/uuid_utils-0.16.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:27a071a899ba46a551d6524dbbc5a98b88be176d0f55ddf72cf71c005326ac10", size = 98683 },
+    { url = "https://files.pythonhosted.org/packages/40/a7/cd1adbea7ef882a70db064c00cd93b12e11027b4cdd7ffd79e95c35fc3e3/uuid_utils-0.16.0-cp313-cp313-win32.whl", hash = "sha256:924a8de04460e4cf65998ad0b6568084f7c51740ebd3254d07a0bcde35a84af6", size = 168822 },
+    { url = "https://files.pythonhosted.org/packages/74/99/617ceb9e3a95b23837012740979baf71afad723b70daf34862da3f7c17a1/uuid_utils-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:5279bc7ab3c6683f1c67314695bee14d869015acbbc677bdb0015190fe753d16", size = 174967 },
+    { url = "https://files.pythonhosted.org/packages/d9/d8/148ae707bfc36d482e39db679c86b81bdce264d4feb9df5d40a03b7687e3/uuid_utils-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:61a9c4c26ad12ac66fa4bfd0fdb8494724fe7a5b98a9fcd43e78e2b388663dbb", size = 173142 },
+    { url = "https://files.pythonhosted.org/packages/21/05/ca6d60705e71fdeaa3431dad94e279a8213c5573cb2925e1aabf3dc0330a/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73486b6aa3f755a6c97000f5ea67e7ac78d6df89bf22980789a1e943e24b74f0", size = 564408 },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/b9a0462c38535c1662acb1025768e2d626bee5ce9e1790bad6b5381162ea/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f1614572fd9345cdc3dde3f40c237345719fabca1aa87d2d87b321d523cfa34d", size = 289923 },
+    { url = "https://files.pythonhosted.org/packages/f2/33/a53afeef1a56051551a0f5a801e4bce411dd73c6a8c99bad16902651256d/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9346ce6eb1fbd8b03a6b331d66016afcb4edcdff6eac708e21391600529a016a", size = 325762 },
+    { url = "https://files.pythonhosted.org/packages/72/ca/4462a4f36365d7ee72d41e05e6bcfe127e861b073ab37c25b2c8a518317c/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a0fc6eb3fd821466fbab69cf356c6ec2b7327266bbbc740a2eb57c77c4bef965", size = 332359 },
+    { url = "https://files.pythonhosted.org/packages/c5/67/9d3373fa7c5a746fdecc64e30caf915c29eb632203508d87676f9243ed03/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13a797e5e8f0dadc18351a5aa013815ddac25dce6864072a539d510910c95f71", size = 445483 },
+    { url = "https://files.pythonhosted.org/packages/57/08/ce01aa6d897fc7f875844fe58cad0a542c8ebf089d9242b654b56260ecb8/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57c3583b1f1c00a94f59726a5e2b988fa209221143919a1af5c2fc24e318fc98", size = 326281 },
+    { url = "https://files.pythonhosted.org/packages/76/ef/2c719b2c26bb5b5e5061a1435c11ad2bd33ac3cd6d4cd0c7c3ac1d3396ed/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:caac9c8b1d50e8fbddc76e93bfefbef472978eb45adbfdb6289d578816992953", size = 350809 },
+    { url = "https://files.pythonhosted.org/packages/e0/9b/c1ed447328b32229cca38ac4c62d309eab006e5e9c4020e2056a175bc607/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:91db59bad97ed2b9d2c6ed25082fe9762b2c422e694fe06786b28cf4e776ac4c", size = 502088 },
+    { url = "https://files.pythonhosted.org/packages/c1/e0/8442f4efe7bde72f0b4ae5f675d0c7fbe209ad0b54718b8ddf43c46c6fae/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:41985e342a30e76366a8becc60bbdb07d72cd1b86ec657b1f31654e9fb1baada", size = 607631 },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/9a9fa261edf4c972f28ae83421377e3ab8dbd0bd7db58fd316e782d09a3b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1b0dcedf9266bf34a54d5cbe78648eaa627e02352f2a6923ed647530aea2f661", size = 567618 },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/1bcfdb9d539bd42736dd6076470a42fbb5db23f79712c0a06aa0a3752f7b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:26fe23ab60f05de4ad70aaa5b6a4c2a7bbd43055e3dd6f6b31efba0532ac9c71", size = 530971 },
+    { url = "https://files.pythonhosted.org/packages/24/0c/18945f417d6bb4d0dd2b7652fe36c58c4e83bcf593b9b326b83aa40b853a/uuid_utils-0.16.0-cp313-cp313t-win32.whl", hash = "sha256:7f8cf49c05d58523a0f977cb7f11afc05791a0fa164d7303b8365a34750638e7", size = 169369 },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/c0eb0c3fab2ed80d706369b750029143b53126809b77b36bcbb77da66bab/uuid_utils-0.16.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e99f9a8b2420b228faba23a637e96efaf5c6a678b2e225870f24431c82707f50", size = 175384 },
+    { url = "https://files.pythonhosted.org/packages/b7/77/50ac87b6e18b1c686f700aa38c9471a990683c6a955f71ac1a6677ed8145/uuid_utils-0.16.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6853b627983aa1b4fd95aa52d9e87136eb94a7b3b7de0fbb1db8a498d457eeec", size = 564108 },
+    { url = "https://files.pythonhosted.org/packages/83/16/65046676de246bb5334d9f58aa96d2feb9fc347fda3556aaff7da1c2fc7a/uuid_utils-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:f44b65ae0c329843817d9c90e36a7a3c677b413bf407c99e67db874dac49dad3", size = 289967 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/54fa988606a15dfd2028e925d8eb9c3ee6edbf1eb7692a67b37282880b56/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de8a365795a76f347f5622621c2bee543cffa0c70949f3ee093bdefc9d926dcc", size = 325835 },
+    { url = "https://files.pythonhosted.org/packages/d5/1b/50622f967ceacea1f89fd065d9bfd395b51acb02cfb0a4ddc8fa9ff0c983/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:426a8c9af90242d879706ccf29da56f0b0712e7739fb0bbe16baacabc75596e2", size = 332607 },
+    { url = "https://files.pythonhosted.org/packages/12/f5/4059706be6617e2787e375ea52994ce3c3fa3920b7d4a9c8ebf7895681a5/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:833bc4b3c3fc24be541f67b01b4a75b6b9942a9b7137395b4eb35435948bd6da", size = 444287 },
+    { url = "https://files.pythonhosted.org/packages/65/d5/f44b2710563da687a368f0ce4dcbd462dfb6708bcd46439d831991d595c7/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efb5252d7c00d586077f10e169d6e6d0b0d0f806d8a085073f0d19b4737aef4e", size = 324949 },
+    { url = "https://files.pythonhosted.org/packages/3a/a7/a69e859e37d26c5603f0bc0ae481860f691224f140e5a832f325b804770d/uuid_utils-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b3377ce388fd7bf8d231ec9d1d4f58c8e87888ddea93581f60ed6f878a4f722", size = 349651 },
+    { url = "https://files.pythonhosted.org/packages/db/73/4139cd3ca7b81ea283c1c8769373e9b2008241c0744a8ffb25f0a1b31325/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:12b6310beb38adc173ec5dc89e98812fd7e3d98f87f3ef01d2ea6ecb5d87994f", size = 502326 },
+    { url = "https://files.pythonhosted.org/packages/cb/8c/858101583fbad1b3fa04da88b1f7170836aa0f00b4cb712063325c44466d/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a49b5a75497643479c919e2e537a4a36224ac3aaa0fada61b75d87024021ac3e", size = 607689 },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/8f3d54a4763dd91ebd0f3d7b0c2ec434e4e0b1fc667b03a44d611a465ec6/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:63bfdf00be51b6b3b79275d6767d034ea5c7a0caa067a35d72861284100cb60a", size = 566214 },
+    { url = "https://files.pythonhosted.org/packages/54/76/4c9a8d9baaa243c7902d84dbba4d51b1ab51c379c66d3fd6368ff6933ecf/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7525bc59ac4579c32317d2493dd42cf134b9bb50cd0bc6a41dd9f77e4740dde6", size = 529989 },
+    { url = "https://files.pythonhosted.org/packages/6d/13/d32cea997f880cedde415730ce0e872ebfd7a040155ae0bbda70eccd208e/uuid_utils-0.16.0-cp314-cp314-win32.whl", hash = "sha256:fbcac6e6710aa2e4bfbb81762758e01470dc56d5048ba4253acc77c9833568ff", size = 169146 },
+    { url = "https://files.pythonhosted.org/packages/1c/19/9fc55172d8fe59e1f27a14d598b427fa508a7ebb35fa7b7b99c24fa0ef13/uuid_utils-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:d23fcaf37368a1647319187ef6f8b741bf079f033065899bc2d00a44b0a1214a", size = 175364 },
+    { url = "https://files.pythonhosted.org/packages/89/5d/fcd9226b715c5aa0638fcdd6deaf0de6c6c3c451c692cd76bfca810c6512/uuid_utils-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:ea3265f8e2b452a4870f3298cb1d183dc4e36a3682cbb264dbe46af31267e706", size = 173268 },
+    { url = "https://files.pythonhosted.org/packages/c1/64/97ec9af95e58b8187f2934008ffab26e1604d149e34fe01c388b0543a24f/uuid_utils-0.16.0-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:99f8420c3ed59f89a086782ac197e257f4b1debb4545dffa90cf5db23f96c892", size = 564464 },
+    { url = "https://files.pythonhosted.org/packages/3e/6d/e4082f407484ac28923c0bf8e861e71d277118d8b7542d0a350340e45350/uuid_utils-0.16.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:259bab73c241743d684dcc3507feb76f484d720545e4e4805582aeff8e19700b", size = 290087 },
+    { url = "https://files.pythonhosted.org/packages/8c/43/c5c5f273c0ff889f20f10344784f9197dd00eb81ccc294330d4b949fea7e/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:897e8ef0dc5e4ac0b17cf9cae84bb41e560d806280ec5b93db7475b504022105", size = 325532 },
+    { url = "https://files.pythonhosted.org/packages/13/7f/669aa899ab5378374d28a28231e6978f739921a1af394c7ebd6cc86e2639/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c5af79cde16a7600dfccb7d431aec0afd3088ff170b6a09887bf3f7ab3cc7c81", size = 332209 },
+    { url = "https://files.pythonhosted.org/packages/2b/57/a2a32406d79a222794ef98a19254fd9a81a029a0f32d7740fba9873bff1f/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bece1a6f677ca36047442c465d8166643eed9818b9e43e0bf42d3cf73e92dcff", size = 445507 },
+    { url = "https://files.pythonhosted.org/packages/26/6b/85459a35bfa7d73e79acbc4eab1cf6aa6e4d9d022c3260ed9dea539c7f0b/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb3444498e7b099499c8a607d7771377020fa55f7274e46f54106af19f752d7", size = 326154 },
+    { url = "https://files.pythonhosted.org/packages/84/9e/e965efdbb503ed14d6e57aec1a22b98326ed24cc2fb48e750c4d192267a0/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:542098f6cb6874aebeff98715f3ab7646fbe0f2ffb24509ca372828c68c4ed0e", size = 350905 },
+    { url = "https://files.pythonhosted.org/packages/23/ae/4321867888a783d03b7c053c0b68ca45d03974d86fcebf44d4ec268db397/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7207b25fe534bcf4d57e0110f90670e61c1c38b6f4598ba855af69ab428fc118", size = 502098 },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/914a47bf42479bff0ce3e1fa1cbe3585354708edc928e27687cf91de9c26/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:16dc5c6e439f75b0456114e955983e2156c1f38887733e54d54205d3005223e4", size = 607032 },
+    { url = "https://files.pythonhosted.org/packages/85/4c/2abacd6badba61a047eaa39c8347656229d12843bd9bbe4906daa6dc752c/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a6d3ee32c57898d8415242b08d5dd086bc4f7bcbbb3fc102ef257f3d793eb294", size = 567664 },
+    { url = "https://files.pythonhosted.org/packages/53/1f/9d1a09521276424da19dc0d74456aed3311170fec181b28fa6acba45d963/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7555f120a2282d1901c9a632c2398a614101af4fe3f7c8114aa0f1d8c1978855", size = 530996 },
+    { url = "https://files.pythonhosted.org/packages/b4/22/14dbedb6b61f492d5524077fd10bbfb137583b0f0aafa6cd870ccb43f39a/uuid_utils-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:756575d082ea4cb7d2f923d5b640c0efe7c82573aab49220c4e09b62d13737ff", size = 169358 },
+    { url = "https://files.pythonhosted.org/packages/25/f4/a636806c98401a1108f2456e9cc3fa39a618145bfb1d0860c57203159cfe/uuid_utils-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:aa50261a83991dbb570a00573741455bd8f3249444f7329e5bdcd494799d1504", size = 174813 },
+    { url = "https://files.pythonhosted.org/packages/75/12/3823742459d87a100deb24bb6b41692aa961b267abd130fa7739cdf7d409/uuid_utils-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:22a17e93a371d850ffce8fcdbacc2239f890efe73aa3262b6170c1febc08afe1", size = 171733 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an opt-in **server-managed conversation state** path for the OpenAI Responses runtime. Instead of the harness resending full rolling history each turn, OpenAI manages history (and compaction) via `previous_response_id`.

The existing `manual_rolling` behavior is fully preserved and unchanged — this is purely additive, selected via `runtime.state: "previous_response_id"`.

## Changes

- **`model_config.py`** — accept `runtime.state: "previous_response_id"` (only valid for `openai-python` + `responses`)
- **`runtime_models.py`** — `ModelResponse.response_id`, populated from the raw response `id`
- **`runtime_adapters.py`** — new `OpenAIResponsesServerStateAdapter`: sends only new messages + `previous_response_id`, sets `store=true`, maps `compact_threshold` → `context_management` compaction
- **`agent.py`** — server-state branch sends the system prompt **once**, then only new user messages each turn; pending buffer flushed only after a successful call; retries don't advance `previous_response_id`; client-side trimming disabled in server mode
- **SDK bump**: `openai==1.72.0` → `2.41.1` (+ lockfile)
- Tests added/updated across config, runtime models, adapters, and agent

## Validation

- `pytest`: **226 passed** (was 206 before)
- `ruff check`: clean
- `mypy`: 18 errors, all pre-existing (verified against merge-base; zero introduced)
- Server-side recall verified end-to-end across a multi-turn chain
- Confirmed that the system prompt is sent once and subsequent turns send only new user messages (no full-history resend)

## ⚠️ Operational note

Server-managed state requires a **non-ZDR** API key (`OPENAI_API_KEY_NO_ZDR`). The standard ZDR `OPENAI_API_KEY` rejects `previous_response_id` with a 400. Operators must point the config's `api_key_env` at a non-ZDR key for real runs.

## Out of scope

`model_configs.yaml` changes are intentionally **not** included in this PR.
