### PR TITLE
Add configurable per-run wall-clock timeout (default 12h)

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -80,6 +80,9 @@ class BenchmarkingAgent(Agent):
         self.MAX_CONTEXT_LENGTH = agent_cfg.get(
             "MAX_CONTEXT_LENGTH", self.MAX_CONTEXT_LENGTH
         )
+        self.MAX_RUNTIME_SECONDS = agent_cfg.get(
+            "MAX_RUNTIME_SECONDS", self.MAX_RUNTIME_SECONDS
+        )
         self.MAX_ANIMATION_FRAMES = agent_cfg.get(
             "MAX_ANIMATION_FRAMES", self.MAX_ANIMATION_FRAMES
         )
@@ -692,6 +695,8 @@ class BenchmarkingAgent(Agent):
                 self.run_record.outcome = "WIN"
             elif self.state is GameState.GAME_OVER:
                 self.run_record.outcome = "GAME_OVER"
+            elif self._timed_out:
+                self.run_record.outcome = "TIMEOUT"
             elif self.action_counter >= self.MAX_ACTIONS:
                 self.run_record.outcome = "MAX_ACTIONS"
             self._write_run_meta()

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -19,9 +19,13 @@ class Agent(ABC):
     """Interface for an agent that plays one ARC-AGI-3 game."""
 
     MAX_ACTIONS: int = 80  # to avoid looping forever if agent doesnt exit
+    # Wall-clock budget for a single run. Defaults to 12 hours; override per
+    # model via the agent config's MAX_RUNTIME_SECONDS field.
+    MAX_RUNTIME_SECONDS: float = 12 * 60 * 60
     ROOT_URL: str
 
     action_counter: int = 0
+    _timed_out: bool = False
 
     timer: float = 0
     agent_name: str
@@ -69,6 +73,14 @@ class Agent(ABC):
             not self.is_done(self.frames, self.frames[-1])
             and self.action_counter <= self.MAX_ACTIONS
         ):
+            if (time.time() - self.timer) >= self.MAX_RUNTIME_SECONDS:
+                self._timed_out = True
+                logger.info(
+                    f"{self.game_id} - Exiting: agent reached "
+                    f"MAX_RUNTIME_SECONDS of {self.MAX_RUNTIME_SECONDS}, "
+                    f"took {self.seconds} seconds ({self.fps} average fps)"
+                )
+                break
             latest_frame = self._convert_raw_frame_data(
                 self.arc_env.observation_space if self.arc_env else None
             )

--- a/benchmarking/model_config.py
+++ b/benchmarking/model_config.py
@@ -123,6 +123,17 @@ def _validate_model_config_entry(entry: Any, index: int, seen_ids: set[str]) -> 
             raise ValueError(
                 f"Model config '{config_id}' agent.analysis_mode must be a boolean."
             )
+    if isinstance(agent, dict) and "MAX_RUNTIME_SECONDS" in agent:
+        max_runtime = agent["MAX_RUNTIME_SECONDS"]
+        if (
+            isinstance(max_runtime, bool)
+            or not isinstance(max_runtime, (int, float))
+            or max_runtime <= 0
+        ):
+            raise ValueError(
+                f"Model config '{config_id}' agent.MAX_RUNTIME_SECONDS must be "
+                f"a positive number (seconds)."
+            )
 
     runtime = entry["runtime"]
     if not isinstance(runtime.get("sdk"), str) or not runtime["sdk"].strip():

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -109,6 +109,48 @@ class TestAgentForcedReset:
         assert agent.forced_observations == []
         assert arc_env.actions == [GameAction.ACTION1]
 
+    def test_main_stops_when_runtime_budget_exceeded(self, monkeypatch):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _TestAgent(arc_env)
+        # Allow several actions so the runtime budget is the limiting factor.
+        agent.MAX_ACTIONS = 100
+        agent.MAX_RUNTIME_SECONDS = 5
+
+        # First call sets the timer (start); the next call (first loop check)
+        # already exceeds the budget, so the loop exits before any action.
+        times = iter([1000.0, 2000.0])
+        monkeypatch.setattr(
+            "benchmarking.base.time.time",
+            lambda: next(times, 2000.0),
+        )
+
+        agent.main()
+
+        assert agent._timed_out is True
+        assert agent.choose_action_calls == []
+        assert arc_env.actions == []
+
+    def test_main_does_not_time_out_within_budget(self, monkeypatch):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _TestAgent(arc_env)
+        agent.MAX_RUNTIME_SECONDS = 10_000
+
+        monkeypatch.setattr("benchmarking.base.time.time", lambda: 1000.0)
+
+        agent.main()
+
+        assert agent._timed_out is False
+        assert arc_env.actions == [GameAction.ACTION1]
+
+    def test_default_runtime_budget_is_twelve_hours(self):
+        assert Agent.MAX_RUNTIME_SECONDS == 12 * 60 * 60
+
     def test_convert_raw_frame_data_preserves_action_input_reasoning(self):
         arc_env = _FakeEnv(
             observation_space=_frame(GameState.NOT_FINISHED),

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -383,6 +383,70 @@ class TestModelConfig:
         ):
             model_config.load_model_configs()
 
+    def test_load_model_configs_accepts_positive_max_runtime_seconds(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "runtime-config",
+                    agent={"MAX_RUNTIME_SECONDS": 3600},
+                )
+            ],
+        )
+
+        configs = model_config.load_model_configs()
+
+        assert configs[0]["agent"]["MAX_RUNTIME_SECONDS"] == 3600
+
+    def test_load_model_configs_rejects_non_positive_max_runtime_seconds(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "bad-runtime-config",
+                    agent={"MAX_RUNTIME_SECONDS": 0},
+                )
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="agent.MAX_RUNTIME_SECONDS must be a positive number",
+        ):
+            model_config.load_model_configs()
+
+    def test_load_model_configs_rejects_non_numeric_max_runtime_seconds(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        _write_model_configs(
+            tmp_path,
+            monkeypatch,
+            [
+                _valid_config(
+                    "bad-runtime-config",
+                    agent={"MAX_RUNTIME_SECONDS": "12h"},
+                )
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="agent.MAX_RUNTIME_SECONDS must be a positive number",
+        ):
+            model_config.load_model_configs()
+
     def test_load_model_configs_rejects_non_mapping_agent_section(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary

Adds a wall-clock time budget for a single run, mirroring how `MAX_ACTIONS` already cuts a job. A run is stopped at a turn boundary once the elapsed time exceeds the budget. Defaults to **12 hours**, overridable per model via the config.

## Behavior

- Checked at the **top of each turn** in the main loop — a turn already in flight finishes, and we stop before starting the next one (cut "when convenient," never mid-turn).
- Logs an info message when it triggers:
  `<game> - Exiting: agent reached MAX_RUNTIME_SECONDS of <n>, took <s> seconds (<fps> average fps)`
- Records `outcome = "TIMEOUT"` in the run metadata.

## Config

Default is `12 * 60 * 60` (43200s). Override in a model config's `agent:` block:

```yaml
agent:
  MAX_RUNTIME_SECONDS: 21600  # 6 hours
```

Validated as a positive number when present.

## Changes

- `benchmarking/base.py` — `MAX_RUNTIME_SECONDS` attr + loop enforcement + log.
- `benchmarking/agent.py` — read override from config; record `TIMEOUT` outcome.
- `benchmarking/model_config.py` — validate the field.
- Tests for loop cutoff, within-budget, default value, and config validation.

## Verification

- `232 passed`
- ruff clean (mypy diff shows only pre-existing, unrelated errors)
