### PR TITLE
Eb/stale cookie fix

### DIFF
--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -92,7 +92,7 @@ class Swarm:
             t.join()
 
         # Refresh arcade cookies with the last agent's cookies
-        if len(self.agents) == 1:
+        if self.agents:
             cookie_agent: Agent = self.agents[-1]
             if isinstance(cookie_agent.arc_env, RemoteEnvironmentWrapper):
                 self._arc._master_cookie_jar.update(cookie_agent.arc_env._master_cookie_jar)

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -6,7 +6,7 @@ import os
 from threading import Thread
 from typing import TYPE_CHECKING, Optional, Type
 
-from arc_agi import Arcade, OperationMode
+from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper
 from arc_agi.scorecard import EnvironmentScorecard
 
 from .agent import BenchmarkingAgent
@@ -90,6 +90,12 @@ class Swarm:
         # wait for all agent to finish
         for t in self.threads:
             t.join()
+
+        # Refresh arcade cookies with the last agent's cookies
+        if len(self.agents) == 1:
+            cookie_agent: Agent = self.agents[-1]
+            if isinstance(cookie_agent.arc_env, RemoteEnvironmentWrapper):
+                self._arc._master_cookie_jar.update(cookie_agent.arc_env._master_cookie_jar)
 
         # all agents are now done
         card_id = self.card_id


### PR DESCRIPTION
Fix swarm stale cookie issue by refreshing the Arcade's cookie collection with fresh cookies from the last (potentially latest to complete) agent's cookies which are stored on the remote environment wrapper. Previously it would use the cookie from scorecard open, which would expire after two hours. The symptom of this was the scorecard close route would occasionally hit the wrong runner that didn't hold the scorecard in memory.