### PR TITLE
EB/stale cookie and exit reason

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 from arcengine import FrameData, GameAction, GameState
 
-from .base import Agent
+from .base import Agent, ExitReason
 from .exceptions import EmptyResponseError
 from .model_config import SERVER_RUNTIME_STATE, get_model_config
 from .recording import RunRecord, StepRecord, StepUsage
@@ -450,6 +450,7 @@ class BenchmarkingAgent(Agent):
 
     def is_done(self, frames: list[FrameData], latest_frame: FrameData) -> bool:
         if latest_frame.state is GameState.WIN:
+            self.exit_reason = ExitReason.GAME_WIN
             return True
         # Check per-level action budget
         if self._level_action_budgets:
@@ -462,6 +463,7 @@ class BenchmarkingAgent(Agent):
                         f"{self.game_id} - Exceeded action budget for level {level}: "
                         f"{self._level_action_counter}/{budget}. Stopping."
                     )
+                    self.exit_reason = ExitReason.ACTION_BUDGET
                     return True
         return False
 

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -76,7 +76,7 @@ class Agent(ABC):
     def main(self) -> None:
         """The main agent loop. Play the game_id until finished, then exits."""
         self.timer = time.time()
-        resolving_action = False
+        taking_action = False
         try:
             while (
                 not self.is_done(self.frames, self.frames[-1])
@@ -87,19 +87,19 @@ class Agent(ABC):
                 )
 
                 # Agent specific implementation
-                resolving_action = True
                 action = self._resolve_action(self.frames, latest_frame)
-                resolving_action = False
+                taking_action = True
                 if frame := self.take_action(action):
                     self.append_frame(frame)
                     logger.info(
                         f"{self.game_id} - {action.name}: count {self.action_counter}, levels completed {frame.levels_completed}, avg fps {self.fps})"
                     )
+                taking_action = False
                 self.action_counter += 1
 
-        except Exception as e:
-            self.exit_reason = ExitReason.AGENT_ERROR if resolving_action else ExitReason.API_ERROR
-            raise e
+        except Exception:
+            self.exit_reason = ExitReason.API_ERROR if taking_action else ExitReason.AGENT_ERROR
+            raise
 
         if self.exit_reason == ExitReason.UNKNOWN and self.action_counter >= self.MAX_ACTIONS:
             self.exit_reason = ExitReason.ACTION_BUDGET

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -19,7 +19,7 @@ class ExitReason(str, Enum):
     UNKNOWN          = "UNKNOWN"
     GAME_WIN         = "GAME_WIN"
     ACTION_BUDGET    = "ACTION_BUDGET"
-    SCORECARD_CLOSED = "SCORECARD_IDLE_LIMIT"
+    SCORECARD_CLOSED = "SCORECARD_CLOSED"
     API_ERROR        = "API_ERROR"
     AGENT_ERROR      = "AGENT_ERROR"
 
@@ -43,7 +43,7 @@ class Agent(ABC):
     arc_env: EnvironmentWrapper
     _previous_action: Optional[GameAction]
 
-    exit_reason: ExitReason = ExitReason.UNKNOWN
+    exit_reason: ExitReason
 
     def __init__(
         self,
@@ -71,6 +71,7 @@ class Agent(ABC):
         }
         self.arc_env = arc_env
         self._previous_action = None
+        self.exit_reason = ExitReason.UNKNOWN
 
     def main(self) -> None:
         """The main agent loop. Play the game_id until finished, then exits."""
@@ -97,10 +98,10 @@ class Agent(ABC):
                 self.action_counter += 1
 
         except Exception as e:
-            self.exit_reason =  ExitReason.AGENT_ERROR if resolving_action else ExitReason.API_ERROR
+            self.exit_reason = ExitReason.AGENT_ERROR if resolving_action else ExitReason.API_ERROR
             raise e
 
-        if self.action_counter >= self.MAX_ACTIONS:
+        if self.exit_reason == ExitReason.UNKNOWN and self.action_counter >= self.MAX_ACTIONS:
             self.exit_reason = ExitReason.ACTION_BUDGET
 
         self.cleanup()

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -19,7 +19,7 @@ class ExitReason(str, Enum):
     UNKNOWN          = "UNKNOWN"
     GAME_WIN         = "GAME_WIN"
     ACTION_BUDGET    = "ACTION_BUDGET"
-    TIME_BUDGET = "ACTION_BUDGET"
+    TIME_BUDGET      = "TIME_BUDGET"
     SCORECARD_CLOSED = "SCORECARD_CLOSED"
     API_ERROR        = "API_ERROR"
     AGENT_ERROR      = "AGENT_ERROR"

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -99,8 +99,8 @@ class Agent(ABC):
                 latest_frame = self._convert_raw_frame_data(
                     self.arc_env.observation_space if self.arc_env else None
                 )
-                taking_action = True
                 action = self._resolve_action(self.frames, latest_frame)
+                taking_action = True
                 if frame := self.take_action(action):
                     self.append_frame(frame)
                     logger.info(

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -16,13 +16,12 @@ from .recorder import Recorder
 logger = logging.getLogger()
 
 class ExitReason(str, Enum):
-    UNKNOWN              = "UNKNOWN"
-    GAME_WIN             = "GAME_WIN"
-    ACTION_BUDGET        = "ACTION_BUDGET"
-    SCORECARD_IDLE_LIMIT = "SCORECARD_IDLE_LIMIT"
-    SCORECARD_TIME_LIMIT = "SCORECARD_TIME_LIMIT"
-    API_ERROR            = "API_ERROR"
-    AGENT_ERROR          = "AGENT_ERROR"
+    UNKNOWN          = "UNKNOWN"
+    GAME_WIN         = "GAME_WIN"
+    ACTION_BUDGET    = "ACTION_BUDGET"
+    SCORECARD_CLOSED = "SCORECARD_IDLE_LIMIT"
+    API_ERROR        = "API_ERROR"
+    AGENT_ERROR      = "AGENT_ERROR"
 
 class Agent(ABC):
     """Interface for an agent that plays one ARC-AGI-3 game."""

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Optional
 
 from arc_agi import EnvironmentWrapper
@@ -14,6 +15,14 @@ from .recorder import Recorder
 
 logger = logging.getLogger()
 
+class ExitReason(str, Enum):
+    UNKNOWN              = "UNKNOWN"
+    GAME_WIN             = "GAME_WIN"
+    ACTION_BUDGET        = "ACTION_BUDGET"
+    SCORECARD_IDLE_LIMIT = "SCORECARD_IDLE_LIMIT"
+    SCORECARD_TIME_LIMIT = "SCORECARD_TIME_LIMIT"
+    API_ERROR            = "API_ERROR"
+    AGENT_ERROR          = "AGENT_ERROR"
 
 class Agent(ABC):
     """Interface for an agent that plays one ARC-AGI-3 game."""
@@ -34,6 +43,8 @@ class Agent(ABC):
     headers: dict[str, str]
     arc_env: EnvironmentWrapper
     _previous_action: Optional[GameAction]
+
+    exit_reason: ExitReason = ExitReason.UNKNOWN
 
     def __init__(
         self,
@@ -65,20 +76,33 @@ class Agent(ABC):
     def main(self) -> None:
         """The main agent loop. Play the game_id until finished, then exits."""
         self.timer = time.time()
-        while (
-            not self.is_done(self.frames, self.frames[-1])
-            and self.action_counter <= self.MAX_ACTIONS
-        ):
-            latest_frame = self._convert_raw_frame_data(
-                self.arc_env.observation_space if self.arc_env else None
-            )
-            action = self._resolve_action(self.frames, latest_frame)
-            if frame := self.take_action(action):
-                self.append_frame(frame)
-                logger.info(
-                    f"{self.game_id} - {action.name}: count {self.action_counter}, levels completed {frame.levels_completed}, avg fps {self.fps})"
+        resolving_action = False
+        try:
+            while (
+                not self.is_done(self.frames, self.frames[-1])
+                and self.action_counter <= self.MAX_ACTIONS
+            ):
+                latest_frame = self._convert_raw_frame_data(
+                    self.arc_env.observation_space if self.arc_env else None
                 )
-            self.action_counter += 1
+
+                # Agent specific implementation
+                resolving_action = True
+                action = self._resolve_action(self.frames, latest_frame)
+                resolving_action = False
+                if frame := self.take_action(action):
+                    self.append_frame(frame)
+                    logger.info(
+                        f"{self.game_id} - {action.name}: count {self.action_counter}, levels completed {frame.levels_completed}, avg fps {self.fps})"
+                    )
+                self.action_counter += 1
+
+        except Exception as e:
+            self.exit_reason =  ExitReason.AGENT_ERROR if resolving_action else ExitReason.API_ERROR
+            raise e
+
+        if self.action_counter >= self.MAX_ACTIONS:
+            self.exit_reason = ExitReason.ACTION_BUDGET
 
         self.cleanup()
 

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -150,7 +150,7 @@ class Swarm:
         except HTTPError as ex:
 
             # Check if scorecard closed due to idle/total time limit
-            if ex.response and ex.response.status_code == 404 and self._scorecard_exists(card_id):
+            if ex.response is not None and ex.response.status_code == 404 and self._scorecard_exists(card_id):
                 for agent in self.agents:
                     if agent.exit_reason == ExitReason.API_ERROR:
                         agent.exit_reason = ExitReason.SCORECARD_CLOSED

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -102,6 +102,11 @@ class Swarm:
         # all agents are now done
         card_id = self.card_id
         scorecard = self.close_scorecard(card_id)
+
+        # Log agent exit reasons
+        for a in self.agents:
+            logger.info(f"AGENT EXIT REASON -- Agent: [{a.agent_name}] Game: [{a.game_id}] Reason: [{a.exit_reason}]")
+
         if scorecard:
             logger.info("--- FINAL SCORECARD REPORT ---")
             logger.info(json.dumps(scorecard.model_dump(), indent=2))
@@ -127,10 +132,10 @@ class Swarm:
         try:
             with requests.Session() as session:
                 session.headers.update(self.headers)
-                response = session.get(f"{self.ROOT_URL}//api/v3/scorecards/{card_id}", timeout=10)
+                response = session.get(f"{self.ROOT_URL}/api/v3/scorecards/{card_id}", timeout=10)
                 return 199 < response.status_code < 300
         except HTTPError as ex:
-            logger.error(ex)
+            logger.exception("HTTPError encountered on check for closed scorecard.")
 
         return False
 
@@ -142,14 +147,14 @@ class Swarm:
         try:
             _scorecard = self._arc.close_scorecard(card_id)
         except HTTPError as ex:
-            # IF 404 on request - check the API to see if the scorecard was already recorded,
-            # then resolve agent exit reasons
+
+            # Check if scorecard closed due to idle/total time limit
             if ex.response.status_code == 404 and self._scorecard_exists(card_id):
                 for agent in self.agents:
                     if agent.exit_reason == ExitReason.API_ERROR:
                         agent.exit_reason = ExitReason.SCORECARD_CLOSED
             else:
-                print("Real error encountered on scorecard close") # TODO error log
+                logger.error("Exception encountered on scorecard close. Swarm exit reason API_ERROR.")
                 raise ex
 
         return _scorecard

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -92,7 +92,7 @@ class Swarm:
             t.join()
 
         # Refresh arcade cookies with the last agent's cookies
-        if len(self.agents) == 1:
+        if self.agents:
             cookie_agent: Agent = self.agents[-1]
             if isinstance(cookie_agent.arc_env, RemoteEnvironmentWrapper):
                 self._arc._master_cookie_jar.update(cookie_agent.arc_env._master_cookie_jar)

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -6,6 +6,7 @@ import os
 from threading import Thread
 from typing import TYPE_CHECKING, Optional, Type
 
+import requests
 from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper, scorecard
 from arc_agi.scorecard import EnvironmentScorecard
 from requests import HTTPError
@@ -122,30 +123,36 @@ class Swarm:
     def open_scorecard(self) -> str:
         return self._arc.open_scorecard(tags=self.tags)  # type: ignore[no-any-return]
 
+    def _scorecard_exists(self, card_id: str) -> bool:
+        try:
+            with requests.Session() as session:
+                session.headers.update(self.headers)
+                response = session.get(f"{self.ROOT_URL}//api/v3/scorecards/{card_id}", timeout=10)
+                return 199 < response.status_code < 300
+        except HTTPError as ex:
+            logger.error(ex)
+
+        return False
+
     def close_scorecard(self, card_id: str) -> Optional[EnvironmentScorecard]:
         self.card_id = None
 
         # Close scorecard gracefully, determine if scorecard automatically closed on initial failure
-        scorecard: Optional[EnvironmentScorecard] = None
+        _scorecard: Optional[EnvironmentScorecard] = None
         try:
-            scorecard = self._arc.close_scorecard(card_id)
+            _scorecard = self._arc.close_scorecard(card_id)
         except HTTPError as ex:
             # IF 404 on request - check the API to see if the scorecard was already recorded,
             # then resolve agent exit reasons
-            if ex.response.status_code == 404:
-                # TODO check if scorecard exists in API
-                scorecard_recorded = True
-
-                if scorecard_recorded:
-                    for agent in self.agents:
-                        if agent.exit_reason == ExitReason.API_ERROR:
-                            # TODO check times
-                            agent.exit_reason = ExitReason.SCORECARD_IDLE_LIMIT
+            if ex.response.status_code == 404 and self._scorecard_exists(card_id):
+                for agent in self.agents:
+                    if agent.exit_reason == ExitReason.API_ERROR:
+                        agent.exit_reason = ExitReason.SCORECARD_CLOSED
             else:
-                print("Real error encountered on scorecard close")
+                print("Real error encountered on scorecard close") # TODO error log
                 raise ex
 
-        return scorecard
+        return _scorecard
 
     def cleanup(self, scorecard: Optional[EnvironmentScorecard] = None) -> None:
         """Cleanup all agents."""

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -156,7 +156,9 @@ class Swarm:
                         agent.exit_reason = ExitReason.SCORECARD_CLOSED
             else:
                 logger.error("Exception encountered on scorecard close. Swarm exit reason API_ERROR.")
-                raise ex
+                for agent in self.agents:
+                    agent.exit_reason = ExitReason.API_ERROR
+                # TODO log the error message
 
         return _scorecard
 

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -6,13 +6,14 @@ import os
 from threading import Thread
 from typing import TYPE_CHECKING, Optional, Type
 
-from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper
+from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper, scorecard
 from arc_agi.scorecard import EnvironmentScorecard
+from requests import HTTPError
 
 from .agent import BenchmarkingAgent
 
 if TYPE_CHECKING:
-    from .base import Agent
+    from .base import Agent, ExitReason
 
 logger = logging.getLogger()
 DEFAULT_AGENT_NAME = BenchmarkingAgent.__name__.lower()
@@ -124,7 +125,27 @@ class Swarm:
     def close_scorecard(self, card_id: str) -> Optional[EnvironmentScorecard]:
         self.card_id = None
 
-        return self._arc.close_scorecard(card_id)
+        # Close scorecard gracefully, determine if scorecard automatically closed on initial failure
+        scorecard: Optional[EnvironmentScorecard] = None
+        try:
+            scorecard = self._arc.close_scorecard(card_id)
+        except HTTPError as ex:
+            # IF 404 on request - check the API to see if the scorecard was already recorded,
+            # then resolve agent exit reasons
+            if ex.response.status_code == 404:
+                # TODO check if scorecard exists in API
+                scorecard_recorded = True
+
+                if scorecard_recorded:
+                    for agent in self.agents:
+                        if agent.exit_reason == ExitReason.API_ERROR:
+                            # TODO check times
+                            agent.exit_reason = ExitReason.SCORECARD_IDLE_LIMIT
+            else:
+                print("Real error encountered on scorecard close")
+                raise ex
+
+        return scorecard
 
     def cleanup(self, scorecard: Optional[EnvironmentScorecard] = None) -> None:
         """Cleanup all agents."""

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -7,14 +7,15 @@ from threading import Thread
 from typing import TYPE_CHECKING, Optional, Type
 
 import requests
-from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper, scorecard
+from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper
 from arc_agi.scorecard import EnvironmentScorecard
 from requests import HTTPError
 
 from .agent import BenchmarkingAgent
+from .base import ExitReason
 
 if TYPE_CHECKING:
-    from .base import Agent, ExitReason
+    from .base import Agent
 
 logger = logging.getLogger()
 DEFAULT_AGENT_NAME = BenchmarkingAgent.__name__.lower()
@@ -134,7 +135,7 @@ class Swarm:
                 session.headers.update(self.headers)
                 response = session.get(f"{self.ROOT_URL}/api/v3/scorecards/{card_id}", timeout=10)
                 return 199 < response.status_code < 300
-        except HTTPError as ex:
+        except requests.RequestException:
             logger.exception("HTTPError encountered on check for closed scorecard.")
 
         return False
@@ -149,7 +150,7 @@ class Swarm:
         except HTTPError as ex:
 
             # Check if scorecard closed due to idle/total time limit
-            if ex.response.status_code == 404 and self._scorecard_exists(card_id):
+            if ex.response and ex.response.status_code == 404 and self._scorecard_exists(card_id):
                 for agent in self.agents:
                     if agent.exit_reason == ExitReason.API_ERROR:
                         agent.exit_reason = ExitReason.SCORECARD_CLOSED

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -6,7 +6,7 @@ import os
 from threading import Thread
 from typing import TYPE_CHECKING, Optional, Type
 
-from arc_agi import Arcade, OperationMode
+from arc_agi import Arcade, OperationMode, RemoteEnvironmentWrapper
 from arc_agi.scorecard import EnvironmentScorecard
 
 from .agent import BenchmarkingAgent
@@ -90,6 +90,12 @@ class Swarm:
         # wait for all agent to finish
         for t in self.threads:
             t.join()
+
+        # Refresh arcade cookies with the last agent's cookies
+        if len(self.agents) == 1:
+            cookie_agent: Agent = self.agents[-1]
+            if isinstance(cookie_agent.arc_env, RemoteEnvironmentWrapper):
+                self._arc._master_cookie_jar.update(cookie_agent.arc_env._master_cookie_jar)
 
         # all agents are now done
         card_id = self.card_id

--- a/benchmarking/swarm.py
+++ b/benchmarking/swarm.py
@@ -155,10 +155,9 @@ class Swarm:
                     if agent.exit_reason == ExitReason.API_ERROR:
                         agent.exit_reason = ExitReason.SCORECARD_CLOSED
             else:
-                logger.error("Exception encountered on scorecard close. Swarm exit reason API_ERROR.")
+                logger.exception("Exception encountered on scorecard close. Swarm exit reason API_ERROR.")
                 for agent in self.agents:
                     agent.exit_reason = ExitReason.API_ERROR
-                # TODO log the error message
 
         return _scorecard
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from arcengine import ActionInput, FrameData, FrameDataRaw, GameAction, GameState
 
-from benchmarking.base import Agent
+from benchmarking.base import Agent, ExitReason
 
 
 class _FakeEnv:
@@ -21,6 +21,13 @@ class _FakeEnv:
         self.actions.append(action)
         self.reasonings.append(reasoning)
         return self.step_frame
+
+
+class _FailingStepEnv(_FakeEnv):
+    """Env whose step() (the ARC API boundary) raises, as on an API error."""
+
+    def step(self, action: GameAction, data: dict, reasoning: dict) -> FrameData:
+        raise RuntimeError("api issue")
 
 
 class _TestAgent(Agent):
@@ -135,3 +142,64 @@ class TestAgentForcedReset:
         assert frame.action_input.id is GameAction.ACTION1
         assert frame.action_input.data == {"x": 1}
         assert frame.action_input.reasoning == {"usage": {"total_tokens": 5}}
+
+
+class _BudgetAgent(_TestAgent):
+    """Never reports done, so main() runs until MAX_ACTIONS is exhausted."""
+
+    MAX_ACTIONS = 2
+
+
+class _ResolveFailsAgent(_TestAgent):
+    """Agent whose action selection (not the API call) raises."""
+
+    MAX_ACTIONS = 5
+
+    def choose_action(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+    ) -> GameAction:
+        raise RuntimeError("model issue")
+
+
+@pytest.mark.unit
+class TestAgentExitReason:
+    def test_main_sets_action_budget_when_max_actions_reached(self):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _BudgetAgent(arc_env)
+
+        agent.main()
+
+        assert agent.action_counter >= agent.MAX_ACTIONS
+        assert agent.exit_reason is ExitReason.ACTION_BUDGET
+
+    def test_main_sets_agent_error_when_resolve_action_raises(self):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _ResolveFailsAgent(arc_env)
+
+        with pytest.raises(RuntimeError, match="model issue"):
+            agent.main()
+
+        # Failure happened before the API call, so it is the agent's fault.
+        assert agent.exit_reason is ExitReason.AGENT_ERROR
+        assert arc_env.actions == []
+
+    def test_main_sets_api_error_when_take_action_raises(self):
+        arc_env = _FailingStepEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _TestAgent(arc_env)
+
+        with pytest.raises(RuntimeError, match="api issue"):
+            agent.main()
+
+        # Failure happened while submitting the action to the ARC API.
+        assert agent.exit_reason is ExitReason.API_ERROR

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -5,6 +5,7 @@ import pytest
 from arcengine import ActionInput, FrameData, FrameDataRaw, GameAction, GameState
 
 from benchmarking.agent import BenchmarkingAgent
+from benchmarking.base import ExitReason
 from benchmarking.runtime_adapters import (
     OpenAIChatCompletionsAdapter,
     OpenAIResponsesAdapter,
@@ -1083,6 +1084,42 @@ def _agent_with_env(step_frame: FrameData) -> BenchmarkingAgent:
     agent.arc_env = SimpleNamespace(step=lambda action, *, data, reasoning: step_frame)
     agent._convert_raw_frame_data = lambda raw: raw
     return agent
+
+
+def _is_done_agent() -> BenchmarkingAgent:
+    agent = BenchmarkingAgent.__new__(BenchmarkingAgent)
+    agent.game_id = "game-id"
+    agent.exit_reason = ExitReason.UNKNOWN
+    agent._level_action_budgets = []
+    agent._level_action_counter = 0
+    agent._last_levels_completed = 0
+    agent._level_just_advanced = False
+    return agent
+
+
+@pytest.mark.unit
+class TestBenchmarkingAgentExitReason:
+    def test_is_done_sets_game_win_on_win_state(self):
+        agent = _is_done_agent()
+
+        assert agent.is_done([], _terminal_frame(GameState.WIN)) is True
+        assert agent.exit_reason is ExitReason.GAME_WIN
+
+    def test_is_done_sets_action_budget_when_level_budget_exhausted(self):
+        agent = _is_done_agent()
+        agent._level_action_budgets = [3]
+        agent._level_action_counter = 3
+
+        assert agent.is_done([], _playable_frame()) is True
+        assert agent.exit_reason is ExitReason.ACTION_BUDGET
+
+    def test_is_done_leaves_reason_unknown_while_under_budget(self):
+        agent = _is_done_agent()
+        agent._level_action_budgets = [10]
+        agent._level_action_counter = 2
+
+        assert agent.is_done([], _playable_frame()) is False
+        assert agent.exit_reason is ExitReason.UNKNOWN
 
 
 @pytest.mark.unit

--- a/tests/unit/test_swarm.py
+++ b/tests/unit/test_swarm.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from requests import HTTPError
 
+from benchmarking.base import ExitReason
 from benchmarking.swarm import Swarm
 
 
@@ -26,6 +28,7 @@ class DummyAgent:
         self.record = record
         self.arc_env = arc_env
         self.config = config
+        self.exit_reason = ExitReason.UNKNOWN
         self.main = Mock()
         self.cleanup = Mock()
         DummyAgent.instances.append(self)
@@ -124,3 +127,65 @@ class TestSwarm:
         assert all(thread.started for thread in FakeThread.instances)
         assert all(thread.joined for thread in FakeThread.instances)
         assert all(agent.cleanup.call_count == 1 for agent in DummyAgent.instances)
+
+
+def _http_error(status_code: int) -> HTTPError:
+    response = SimpleNamespace(status_code=status_code)
+    return HTTPError(response=response)
+
+
+class _ExitAgent:
+    """Minimal agent stub exposing only what close_scorecard reads."""
+
+    def __init__(self, exit_reason: ExitReason) -> None:
+        self.exit_reason = exit_reason
+        self.agent_name = "agent"
+        self.game_id = "game"
+
+
+def _swarm_with_agents(agents: list[_ExitAgent], close_error: HTTPError) -> Swarm:
+    with (
+        patch("benchmarking.swarm.BenchmarkingAgent", DummyAgent),
+        patch("benchmarking.swarm.Arcade", FakeArcade),
+    ):
+        swarm = Swarm(ROOT_URL="https://example.com", games=["game1"])
+    swarm.agents = agents
+    swarm._arc.close_scorecard = Mock(side_effect=close_error)
+    return swarm
+
+
+@pytest.mark.unit
+class TestSwarmCloseScorecard:
+    def test_idle_closed_scorecard_reclassifies_only_api_error_agents(self):
+        api_agent = _ExitAgent(ExitReason.API_ERROR)
+        win_agent = _ExitAgent(ExitReason.GAME_WIN)
+        swarm = _swarm_with_agents([api_agent, win_agent], _http_error(404))
+
+        with patch.object(Swarm, "_scorecard_exists", return_value=True):
+            result = swarm.close_scorecard("card-123")
+
+        assert result is None
+        assert api_agent.exit_reason is ExitReason.SCORECARD_CLOSED
+        assert win_agent.exit_reason is ExitReason.GAME_WIN
+        assert swarm.card_id is None
+
+    def test_404_but_scorecard_absent_reraises_and_keeps_reasons(self):
+        api_agent = _ExitAgent(ExitReason.API_ERROR)
+        swarm = _swarm_with_agents([api_agent], _http_error(404))
+
+        with patch.object(Swarm, "_scorecard_exists", return_value=False):
+            with pytest.raises(HTTPError):
+                swarm.close_scorecard("card-123")
+
+        assert api_agent.exit_reason is ExitReason.API_ERROR
+
+    def test_non_404_error_reraises_without_existence_check(self):
+        api_agent = _ExitAgent(ExitReason.API_ERROR)
+        swarm = _swarm_with_agents([api_agent], _http_error(500))
+
+        with patch.object(Swarm, "_scorecard_exists") as exists:
+            with pytest.raises(HTTPError):
+                swarm.close_scorecard("card-123")
+
+        exists.assert_not_called()
+        assert api_agent.exit_reason is ExitReason.API_ERROR

--- a/tests/unit/test_swarm.py
+++ b/tests/unit/test_swarm.py
@@ -174,8 +174,7 @@ class TestSwarmCloseScorecard:
         swarm = _swarm_with_agents([api_agent], _http_error(404))
 
         with patch.object(Swarm, "_scorecard_exists", return_value=False):
-            with pytest.raises(HTTPError):
-                swarm.close_scorecard("card-123")
+            swarm.close_scorecard("card-123")
 
         assert api_agent.exit_reason is ExitReason.API_ERROR
 
@@ -184,8 +183,7 @@ class TestSwarmCloseScorecard:
         swarm = _swarm_with_agents([api_agent], _http_error(500))
 
         with patch.object(Swarm, "_scorecard_exists") as exists:
-            with pytest.raises(HTTPError):
-                swarm.close_scorecard("card-123")
+            swarm.close_scorecard("card-123")
 
         exists.assert_not_called()
         assert api_agent.exit_reason is ExitReason.API_ERROR


### PR DESCRIPTION
- Introduce `ExitReason` enum with the set of reasons an agent may exit a benchmark run.
- If api calls to close the scorecard return a 404, check if the scorecard has been published to the API (autoclose on runners does this) to determine if the scorecard was closed due to idle/timeout.
- Swarm logs all agent close reasons at the end of a run