### PR TITLE
Parse structured action responses

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -285,10 +285,68 @@ class BenchmarkingAgent(Agent):
 
     # ── Action parsing ───────────────────────────────────────────────────
 
+    @staticmethod
+    def _parse_structured_action(
+        payload: dict[str, Any],
+        available_actions: list[GameAction],
+    ) -> Optional[GameAction]:
+        """Validate one available action and its required arguments."""
+        # 1. Envelope: only `actions`, containing exactly one object.
+        actions = payload.get("actions")
+        valid_envelope = (
+            set(payload) == {"actions"}
+            and isinstance(actions, list)
+            and len(actions) == 1
+        )
+        if not valid_envelope:
+            return None
+        entry = actions[0]
+        if not isinstance(entry, dict):
+            return None
+
+        # 2. Availability: the exact action name must be offered this turn.
+        action = next(
+            (a for a in available_actions if a.name == entry.get("action_type")),
+            None,
+        )
+        if action is None:
+            return None
+
+        # 3. Shape: simple actions have no arguments; complex actions require x/y.
+        expected_fields = {"action_type", "x", "y"}
+        if not action.is_complex():
+            expected_fields = {"action_type"}
+        if set(entry) != expected_fields:
+            return None
+        parsed = GameAction.from_name(action.name)
+        if not action.is_complex():
+            return parsed
+
+        # 4. Coordinates: genuine integers within the game grid.
+        x, y = entry["x"], entry["y"]
+        invalid_coordinate = any(
+            type(value) is not int or not 0 <= value <= 63 for value in (x, y)
+        )
+        if invalid_coordinate:
+            return None
+        parsed.set_data({"x": x, "y": y})
+        return parsed
+
     def _parse_action(
         self, text: str, available_actions: list[GameAction]
     ) -> Optional[GameAction]:
-        """Parse the last mentioned action from the assistant's response."""
+        """Parse a structured action or fall back to legacy text parsing."""
+        try:
+            payload = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+
+        # A response with `actions` claims the structured schema. Validate it
+        # strictly; invalid structured responses must not fall through to regex.
+        if isinstance(payload, dict) and "actions" in payload:
+            return self._parse_structured_action(payload, available_actions)
+
+        # Legacy free-text responses execute the last valid action mentioned.
         text_upper = text.upper()
         candidates: list[tuple[int, GameAction]] = []
 

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -404,6 +404,86 @@ class TestBenchmarkingAgentModelRequests:
 
 
 @pytest.mark.unit
+class TestBenchmarkingAgentActionParsing:
+    def test_parses_observed_single_complex_action_json(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        action = agent._parse_action(
+            '{"actions":[{"action_type":"ACTION6","x":26,"y":36}]}',
+            [GameAction.ACTION6],
+        )
+
+        assert action is not None
+        assert action.name == "ACTION6"
+        assert action.action_data.x == 26
+        assert action.action_data.y == 36
+
+    def test_parses_single_simple_action_json(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        action = agent._parse_action(
+            '{"actions": [{"action_type": "ACTION5"}]}',
+            [GameAction.ACTION5],
+        )
+
+        assert action == GameAction.ACTION5
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            '{"actions":[]}',
+            (
+                '{"actions":['
+                '{"action_type":"ACTION6","x":26,"y":36},'
+                '{"action_type":"ACTION6","x":25,"y":36}'
+                ']}'
+            ),
+            '{"actions":[{"action_type":"ACTION6","x":26}]}',
+            '{"actions":[{"action_type":"ACTION6","x":"26","y":36}]}',
+            '{"actions":[{"action_type":"ACTION6","x":26.0,"y":36}]}',
+            '{"actions":[{"action_type":"ACTION6","x":true,"y":36}]}',
+            '{"actions":[{"action_type":"ACTION6","x":64,"y":36}]}',
+            (
+                '{"actions":[{"action_type":"ACTION6","x":26,"y":36,'
+                '"note":"ACTION6 26 36"}]}'
+            ),
+            (
+                '{"actions":[{"action_type":"ACTION6","x":26,"y":36}],'
+                '"metadata":{}}'
+            ),
+        ],
+    )
+    def test_rejects_invalid_or_ambiguous_structured_actions(self, response):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        assert agent._parse_action(response, [GameAction.ACTION6]) is None
+
+    def test_rejects_structured_action_that_is_not_available(self):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        action = agent._parse_action(
+            '{"actions":[{"action_type":"ACTION6","x":26,"y":36}]}',
+            [GameAction.ACTION5],
+        )
+
+        assert action is None
+
+    @pytest.mark.parametrize(
+        "response",
+        ["ACTION6 26 36", "ACTION6: 26, 36", "ACTION6(26, 36)"],
+    )
+    def test_existing_complex_action_formats_still_parse(self, response):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+
+        action = agent._parse_action(response, [GameAction.ACTION6])
+
+        assert action is not None
+        assert action.name == "ACTION6"
+        assert action.action_data.x == 26
+        assert action.action_data.y == 36
+
+
+@pytest.mark.unit
 class TestBenchmarkingAgentRetries:
     def test_unparseable_assistant_response_retries_until_action_is_parsed(self):
         agent = _agent_for_request_kwargs(


### PR DESCRIPTION
## What changed

- Parse the observed structured response shape `{"actions":[{"action_type":"ACTION6","x":26,"y":36}]}` before the existing text parser.
- Strictly validate a single available action, exact fields, and integer coordinates in the 0–63 range.
- Reject malformed or ambiguous structured payloads without falling through to permissive regex matching.
- Preserve all existing legacy action formats.

## Why

Models can return a valid ARC action as structured JSON. The shared parser previously recognized only free-text action mentions, causing valid complex actions such as `ACTION6` to exhaust all retries.

## Validation

- `264 passed` across the full pytest suite.
- Ruff passes for the changed implementation and tests.
- Production LS20 smoke test, GPT-5.6 Terra, encrypted replay: 10/10 actions parsed with zero retries; scorecard `c56d1912-29d2-476d-9538-4f0269024d8a`.
- Production LS20 smoke test, GPT-5.6 Terra, manual/non-encrypted state: 10/10 actions parsed with zero retries; scorecard `98050248-3976-482f-a6ce-5892b99fb9f6`.

Terra emitted legacy action text during the smoke tests, confirming backward compatibility. The structured JSON success and rejection paths are covered directly by unit tests.
