### PR TITLE
Add bounded model retry backoff

### DIFF
--- a/benchmarking/agent.py
+++ b/benchmarking/agent.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import os
+import random
 import re
 import textwrap
 import time
@@ -40,7 +41,10 @@ class BenchmarkingAgent(Agent):
     MODEL_CONFIG_ID: str = ""
     MAX_ACTIONS: int = 10  # Fallback only when baseline_actions are unavailable.
     MAX_ACTIONS_BASELINE_MULTIPLIER: float = 2.0
-    MAX_RETRIES: int = 3
+    MAX_RETRIES: int = 10
+    RETRY_INITIAL_DELAY_SECONDS: float = 0.5
+    RETRY_MAX_DELAY_SECONDS: float = 8.0
+    RETRY_JITTER_RATIO: float = 0.25
     MAX_CONTEXT_LENGTH: int = 100000
     MAX_ANIMATION_FRAMES: int = 7
     analysis_mode: bool = False
@@ -88,6 +92,15 @@ class BenchmarkingAgent(Agent):
             "MAX_ANIMATION_FRAMES", self.MAX_ANIMATION_FRAMES
         )
         self.MAX_RETRIES = agent_cfg.get("MAX_RETRIES", self.MAX_RETRIES)
+        self.RETRY_INITIAL_DELAY_SECONDS = agent_cfg.get(
+            "RETRY_INITIAL_DELAY_SECONDS", self.RETRY_INITIAL_DELAY_SECONDS
+        )
+        self.RETRY_MAX_DELAY_SECONDS = agent_cfg.get(
+            "RETRY_MAX_DELAY_SECONDS", self.RETRY_MAX_DELAY_SECONDS
+        )
+        self.RETRY_JITTER_RATIO = agent_cfg.get(
+            "RETRY_JITTER_RATIO", self.RETRY_JITTER_RATIO
+        )
         self.analysis_mode = agent_cfg.get("analysis_mode", self.analysis_mode)
 
         # Per-level action budgets from baseline_actions * multiplier.
@@ -643,6 +656,50 @@ class BenchmarkingAgent(Agent):
 
     # ── API calls & retries ────────────────────────────────────────────
 
+    def _remaining_runtime_seconds(self) -> float | None:
+        timer = getattr(self, "timer", 0.0)
+        if not timer:
+            return None
+        elapsed = max(0.0, time.time() - timer)
+        return max(0.0, self.MAX_RUNTIME_SECONDS - elapsed)
+
+    def _raise_retry_runtime_exhausted(self) -> None:
+        self._timed_out = True
+        self.exit_reason = ExitReason.TIME_BUDGET
+        raise TimeoutError(
+            "Model retry would exceed the remaining MAX_RUNTIME_SECONDS budget."
+        )
+
+    def _retry_delay_seconds(self, attempt: int) -> float:
+        exponential_delay = self.RETRY_INITIAL_DELAY_SECONDS * (2**attempt)
+        jitter = 1.0 - (self.RETRY_JITTER_RATIO * random.random())
+        return max(0.0, min(exponential_delay * jitter, self.RETRY_MAX_DELAY_SECONDS))
+
+    def _sleep_before_retry(self, attempt: int, failure_kind: str) -> None:
+        if attempt >= self.MAX_RETRIES:
+            return
+
+        delay = self._retry_delay_seconds(attempt)
+        remaining_runtime = self._remaining_runtime_seconds()
+        if remaining_runtime is not None and delay >= remaining_runtime:
+            logger.warning(
+                "Stopping retries after %s because the %.2fs backoff would "
+                "exceed the %.2fs remaining runtime budget.",
+                failure_kind,
+                delay,
+                remaining_runtime,
+            )
+            self._raise_retry_runtime_exhausted()
+
+        logger.info(
+            "Retrying after %s in %.2f seconds (next attempt %s/%s).",
+            failure_kind,
+            delay,
+            attempt + 2,
+            self.MAX_RETRIES + 1,
+        )
+        time.sleep(delay)
+
     def _request_with_retries(
         self, actions: list[GameAction]
     ) -> tuple[ModelResponse, GameAction, int, list[dict[str, Any]]]:
@@ -654,6 +711,10 @@ class BenchmarkingAgent(Agent):
         """
         accumulated_usage = NormalizedUsage()
         for attempt in range(self.MAX_RETRIES + 1):
+            remaining_runtime = self._remaining_runtime_seconds()
+            if remaining_runtime is not None and remaining_runtime <= 0:
+                self._raise_retry_runtime_exhausted()
+
             try:
                 # Server-managed state compacts on OpenAI's side; the docs say not
                 # to manually prune when chaining via previous_response_id.
@@ -664,16 +725,21 @@ class BenchmarkingAgent(Agent):
             except EmptyResponseError as e:
                 if e.response is not None:
                     self._save_diagnostic(e.response)
+                if isinstance(e.usage, NormalizedUsage):
+                    self.track_tokens(e.usage.total_tokens)
+                    accumulated_usage = accumulated_usage + e.usage
                 logger.warning(
                     f"Empty API response "
                     f"(attempt {attempt + 1}/{self.MAX_RETRIES + 1})."
                 )
+                self._sleep_before_retry(attempt, "empty API response")
                 continue
             except Exception as e:
                 logger.warning(
                     f"API error: {type(e).__name__}: {e} "
                     f"(attempt {attempt + 1}/{self.MAX_RETRIES + 1})."
                 )
+                self._sleep_before_retry(attempt, "API error")
                 continue
 
             self.track_tokens(model_response.usage.total_tokens)
@@ -696,6 +762,7 @@ class BenchmarkingAgent(Agent):
                 f"Could not parse action from response "
                 f"(attempt {attempt + 1}/{self.MAX_RETRIES + 1})."
             )
+            self._sleep_before_retry(attempt, "unparseable response")
 
         raise RuntimeError(
             f"Failed to get a valid action after {self.MAX_RETRIES + 1} attempts."

--- a/benchmarking/base.py
+++ b/benchmarking/base.py
@@ -110,7 +110,12 @@ class Agent(ABC):
                 self.action_counter += 1
 
         except Exception:
-            self.exit_reason = ExitReason.API_ERROR if taking_action else ExitReason.AGENT_ERROR
+            if self._timed_out:
+                self.exit_reason = ExitReason.TIME_BUDGET
+            else:
+                self.exit_reason = (
+                    ExitReason.API_ERROR if taking_action else ExitReason.AGENT_ERROR
+                )
             raise
 
         if self.exit_reason == ExitReason.UNKNOWN and self.action_counter >= self.MAX_ACTIONS:

--- a/benchmarking/exceptions.py
+++ b/benchmarking/exceptions.py
@@ -1,6 +1,12 @@
 class EmptyResponseError(Exception):
     """Raised when the API returns HTTP 200 but with null/empty choices."""
 
-    def __init__(self, message: str, response: object | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        response: object | None = None,
+        usage: object | None = None,
+    ) -> None:
         super().__init__(message)
         self.response = response
+        self.usage = usage

--- a/benchmarking/runtime_models.py
+++ b/benchmarking/runtime_models.py
@@ -341,60 +341,84 @@ def _extract_responses_reasoning_text(response: Any) -> str | None:
 
 
 def normalize_chat_completion_response(response: Any) -> ModelResponse:
+    usage = NormalizedUsage(
+        **_normalize_chat_usage(getattr(response, "usage", None))
+    )
     if not getattr(response, "choices", None):
         raise EmptyResponseError(
             "API returned 200 with empty choices.",
             response=response,
+            usage=usage,
         )
 
     message = response.choices[0].message
-    usage = getattr(response, "usage", None)
 
     return ModelResponse(
         output_text=message.content or "",
         reasoning_text=getattr(message, "reasoning", None)
         or getattr(message, "reasoning_content", None),
-        usage=NormalizedUsage(**_normalize_chat_usage(usage)),
+        usage=usage,
         raw_response=response,
     )
 
 
 def normalize_responses_response(response: Any) -> ModelResponse:
+    usage = NormalizedUsage(
+        **_normalize_responses_usage(
+            _value_from_response_object(response, "usage"),
+        )
+    )
+    try:
+        output_text = _extract_responses_output_text(response)
+    except EmptyResponseError as error:
+        error.usage = usage
+        raise
+
     return ModelResponse(
-        output_text=_extract_responses_output_text(response),
+        output_text=output_text,
         reasoning_text=_extract_responses_reasoning_text(response),
-        usage=NormalizedUsage(
-            **_normalize_responses_usage(
-                _value_from_response_object(response, "usage"),
-            )
-        ),
+        usage=usage,
         raw_response=response,
         response_id=_value_from_response_object(response, "id"),
     )
 
 
 def normalize_google_genai_response(response: Any) -> ModelResponse:
+    usage = NormalizedUsage(
+        **_normalize_google_genai_usage(
+            _value_from_response_object(response, "usage_metadata"),
+        )
+    )
+    try:
+        output_text = _extract_google_genai_output_text(response)
+    except EmptyResponseError as error:
+        error.usage = usage
+        raise
+
     return ModelResponse(
-        output_text=_extract_google_genai_output_text(response),
+        output_text=output_text,
         reasoning_text=_extract_google_genai_reasoning_text(response),
-        usage=NormalizedUsage(
-            **_normalize_google_genai_usage(
-                _value_from_response_object(response, "usage_metadata"),
-            )
-        ),
+        usage=usage,
         raw_response=response,
     )
 
 
 def normalize_anthropic_messages_response(response: Any) -> ModelResponse:
+    usage = NormalizedUsage(
+        **_normalize_anthropic_messages_usage(
+            _value_from_response_object(response, "usage"),
+        )
+    )
+    try:
+        output_text = _extract_anthropic_messages_output_text(response)
+    except EmptyResponseError as error:
+        error.usage = usage
+        raise
+
     return ModelResponse(
-        output_text=_extract_anthropic_messages_output_text(response),
+        output_text=output_text,
         reasoning_text=None,
-        usage=NormalizedUsage(
-            **_normalize_anthropic_messages_usage(
-                _value_from_response_object(response, "usage"),
-            )
-        ),
+        usage=usage,
         raw_response=response,
     )
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,10 @@ import requests
 
 from benchmarking import BenchmarkingAgent, Swarm
 from benchmarking.cli_list import print_requested_resource_lists
-from benchmarking.model_config import get_model_config, list_model_config_ids
+from benchmarking.model_config import (
+    get_model_config,
+    list_model_config_ids,  # noqa: F401
+)
 
 logger = logging.getLogger()
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -205,6 +205,20 @@ class _ResolveFailsAgent(_TestAgent):
         raise RuntimeError("model issue")
 
 
+class _RetryTimeoutAgent(_TestAgent):
+    """Agent whose model retry loop exhausts the run's time budget."""
+
+    MAX_ACTIONS = 5
+
+    def choose_action(
+        self,
+        frames: list[FrameData],
+        latest_frame: FrameData,
+    ) -> GameAction:
+        self._timed_out = True
+        raise TimeoutError("retry budget exhausted")
+
+
 @pytest.mark.unit
 class TestAgentExitReason:
     def test_main_sets_action_budget_when_max_actions_reached(self):
@@ -245,3 +259,16 @@ class TestAgentExitReason:
 
         # Failure happened while submitting the action to the ARC API.
         assert agent.exit_reason is ExitReason.API_ERROR
+
+    def test_main_preserves_time_budget_when_retry_wait_would_exceed_runtime(self):
+        arc_env = _FakeEnv(
+            observation_space=_frame(GameState.NOT_FINISHED),
+            step_frame=_frame(GameState.NOT_FINISHED),
+        )
+        agent = _RetryTimeoutAgent(arc_env)
+
+        with pytest.raises(TimeoutError, match="retry budget exhausted"):
+            agent.main()
+
+        assert agent.exit_reason is ExitReason.TIME_BUDGET
+        assert arc_env.actions == []

--- a/tests/unit/test_benchmarking_agent.py
+++ b/tests/unit/test_benchmarking_agent.py
@@ -10,6 +10,7 @@ from benchmarking.action_metadata import (
 )
 from benchmarking.agent import BenchmarkingAgent
 from benchmarking.base import ExitReason
+from benchmarking.exceptions import EmptyResponseError
 from benchmarking.runtime_adapters import (
     OpenAIChatCompletionsAdapter,
     OpenAIResponsesAdapter,
@@ -65,6 +66,9 @@ def _agent_for_request_kwargs(request_kwargs: dict) -> BenchmarkingAgent:
     agent.MAX_CONTEXT_LENGTH = 1_000
     agent.ESTIMATED_CHARS_PER_TOKEN = 1.0
     agent.MAX_RETRIES = 2
+    agent.RETRY_INITIAL_DELAY_SECONDS = 0.0
+    agent.RETRY_MAX_DELAY_SECONDS = 0.0
+    agent.RETRY_JITTER_RATIO = 0.0
     agent.analysis_mode = False
     agent.token_counter = 0
     agent._server_state = False
@@ -485,6 +489,94 @@ class TestBenchmarkingAgentActionParsing:
 
 @pytest.mark.unit
 class TestBenchmarkingAgentRetries:
+    def test_default_retry_count_is_ten(self):
+        assert BenchmarkingAgent.MAX_RETRIES == 10
+
+    def test_retry_backoff_doubles_then_caps_and_skips_final_wait(
+        self, monkeypatch
+    ):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.MAX_RETRIES = 10
+        agent.RETRY_INITIAL_DELAY_SECONDS = 0.5
+        agent.RETRY_MAX_DELAY_SECONDS = 8.0
+        agent.RETRY_JITTER_RATIO = 0.25
+        sleeps = []
+        monkeypatch.setattr("benchmarking.agent.random.random", lambda: 0.0)
+        monkeypatch.setattr("benchmarking.agent.time.sleep", sleeps.append)
+
+        for attempt in range(agent.MAX_RETRIES + 1):
+            agent._sleep_before_retry(attempt, "empty API response")
+
+        assert sleeps == [0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+
+    def test_empty_response_usage_is_included_after_success(self):
+        agent = _agent_for_request_kwargs({"model": "claude-opus-4-7"})
+        agent.conversation = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "frame"},
+        ]
+        diagnostics = []
+        agent._save_diagnostic = diagnostics.append
+        calls = 0
+        empty_response = object()
+
+        def fake_call_api(_request: ModelRequest) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise EmptyResponseError(
+                    "empty",
+                    response=empty_response,
+                    usage=NormalizedUsage(
+                        input_tokens=15,
+                        output_tokens=7,
+                        total_tokens=22,
+                    ),
+                )
+            return ModelResponse(
+                output_text="RESET",
+                usage=NormalizedUsage(
+                    input_tokens=15,
+                    output_tokens=3,
+                    total_tokens=18,
+                ),
+            )
+
+        agent._call_api = fake_call_api
+
+        model_response, action, retries, _messages_sent = agent._request_with_retries(
+            [GameAction.RESET]
+        )
+
+        assert action == GameAction.RESET
+        assert retries == 1
+        assert diagnostics == [empty_response]
+        assert model_response.usage.input_tokens == 30
+        assert model_response.usage.output_tokens == 10
+        assert model_response.usage.total_tokens == 40
+        assert agent.token_counter == 40
+
+    def test_retry_backoff_stops_before_exceeding_runtime(self, monkeypatch):
+        agent = _agent_for_request_kwargs({"model": "gpt-5.4"})
+        agent.MAX_RETRIES = 10
+        agent.RETRY_INITIAL_DELAY_SECONDS = 0.5
+        agent.RETRY_MAX_DELAY_SECONDS = 8.0
+        agent.RETRY_JITTER_RATIO = 0.0
+        agent.MAX_RUNTIME_SECONDS = 5.0
+        agent.timer = 100.0
+        agent._timed_out = False
+        agent.exit_reason = ExitReason.UNKNOWN
+        sleeps = []
+        monkeypatch.setattr("benchmarking.agent.time.time", lambda: 104.75)
+        monkeypatch.setattr("benchmarking.agent.time.sleep", sleeps.append)
+
+        with pytest.raises(TimeoutError, match="remaining MAX_RUNTIME_SECONDS"):
+            agent._sleep_before_retry(0, "empty API response")
+
+        assert sleeps == []
+        assert agent._timed_out is True
+        assert agent.exit_reason is ExitReason.TIME_BUDGET
+
     def test_unparseable_assistant_response_retries_until_action_is_parsed(self):
         agent = _agent_for_request_kwargs(
             {"model": "gpt-5.4", "max_completion_tokens": 128}

--- a/tests/unit/test_runtime_models.py
+++ b/tests/unit/test_runtime_models.py
@@ -500,6 +500,9 @@ class TestRuntimeModels:
 
         assert str(exc_info.value) == "API returned 200 with empty output."
         assert exc_info.value.response is raw_response
+        assert exc_info.value.usage.input_tokens == 15
+        assert exc_info.value.usage.output_tokens == 7
+        assert exc_info.value.usage.total_tokens == 22
 
     def test_anthropic_messages_content_without_text_raises_empty_response_error(self):
         raw_response = _anthropic_response(
@@ -511,6 +514,9 @@ class TestRuntimeModels:
 
         assert str(exc_info.value) == "API returned 200 with empty output."
         assert exc_info.value.response is raw_response
+        assert exc_info.value.usage.input_tokens == 15
+        assert exc_info.value.usage.output_tokens == 7
+        assert exc_info.value.usage.total_tokens == 22
 
     def test_anthropic_messages_raw_response_is_preserved(self):
         raw_response = _anthropic_response()
@@ -569,7 +575,9 @@ class TestRuntimeModels:
 
     def test_google_genai_normalizer_raises_when_no_visible_text_parts(self):
         response = _google_genai_response(
-            parts=[_google_genai_part(text="hidden thought", thought=True)]
+            parts=[_google_genai_part(text="hidden thought", thought=True)],
+            candidates_token_count=0,
+            thoughts_token_count=7,
         )
 
         with pytest.raises(EmptyResponseError) as exc_info:
@@ -577,6 +585,9 @@ class TestRuntimeModels:
 
         assert str(exc_info.value) == "API returned 200 with empty output."
         assert exc_info.value.response is response
+        assert exc_info.value.usage.input_tokens == 11
+        assert exc_info.value.usage.output_tokens == 7
+        assert exc_info.value.usage.reasoning_tokens == 7
 
     def test_google_genai_normalizer_raises_when_no_candidates(self):
         response = SimpleNamespace(
@@ -590,8 +601,11 @@ class TestRuntimeModels:
             ),
         )
 
-        with pytest.raises(EmptyResponseError):
+        with pytest.raises(EmptyResponseError) as exc_info:
             normalize_google_genai_response(response)
+
+        assert exc_info.value.usage.input_tokens == 5
+        assert exc_info.value.usage.total_tokens == 5
 
     def test_google_genai_normalizer_maps_prompt_to_input_tokens(self):
         model_response = normalize_google_genai_response(


### PR DESCRIPTION
## Summary

This changes the model-level retry loop that currently retries empty HTTP 200 responses immediately. The observed Anthropic failure made four nearly back-to-back requests because `MAX_RETRIES=3` and the loop had no wait between attempts.

- Increase the default from 3 retries to 10 retries (11 total attempts under the existing `MAX_RETRIES + 1` semantics).
- Add exponential backoff beginning at 0.5 seconds, capped at 8 seconds, with up to 25% downward jitter. Backoff applies to empty responses, API errors that escape the SDK, and responses without a parseable action.
- Do not sleep after the final attempt.
- Check the run's remaining `MAX_RUNTIME_SECONDS` before calls and before waits. If the next wait would exceed the remaining budget, stop and preserve `TIME_BUDGET` as the exit reason.
- Preserve normalized usage from empty HTTP 200 responses and add it to the eventual successful step's token and cost totals. The raw response diagnostic behavior remains unchanged.
- Mark the intentional `list_model_config_ids` compatibility re-export so the repository-wide Ruff check passes.

## Operational impact

For a persistent empty response, the outer loop can now issue up to 11 model calls instead of 4. The ten waits total approximately 52-56 seconds, depending on jitter, plus provider request time. The Anthropic SDK's transport/status retry policy remains separate and unchanged.

The higher retry ceiling is intended to improve recovery from transient empty responses. The cap prevents the unbounded 17-minute wait that a 1-second, ten-step exponential schedule would otherwise produce.

Usage returned with failed empty responses is now visible in the successful step and run totals. This avoids understating tokens and calculated cost when a later attempt succeeds.

## Tests

- `uv run ruff check .`
- `uv run pytest` (279 passed)
- Added coverage for the retry count, exponential schedule and cap, no final sleep, empty-response usage accumulation, runtime-budget cutoff, and timeout exit reason.
